### PR TITLE
Fix pip installation

### DIFF
--- a/src/home_robot/setup.py
+++ b/src/home_robot/setup.py
@@ -2,15 +2,14 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from setuptools import setup
+from setuptools import setup, find_packages
 
 install_requires = ["numpy<1.24", "scipy", "hydra-core", "yacs"]
 
 setup(
     name="home-robot",
     version="0.1.0",
-    packages=["home_robot"],
-    package_dir={"": "."},
+    packages=find_packages(where="."),
     install_requires=install_requires,
     include_package_data=True,
 )

--- a/src/home_robot/setup.py
+++ b/src/home_robot/setup.py
@@ -12,5 +12,5 @@ setup(
     packages=["home_robot"],
     package_dir={"": "."},
     install_requires=install_requires,
-    zip_safe=False,
+    include_package_data=True,
 )

--- a/src/home_robot_client/setup.py
+++ b/src/home_robot_client/setup.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from setuptools import setup
+from setuptools import setup, find_packages
 
 install_requires = [
     "numpy",
@@ -13,8 +13,7 @@ install_requires = [
 setup(
     name="home-robot-client",
     version="0.1.0",
-    packages=["home_robot_client"],
-    package_dir={"": "."},
+    packages=find_packages(where="."),
     install_requires=install_requires,
-    zip_safe=False,
+    include_package_data=True,
 )

--- a/src/home_robot_hw/setup.py
+++ b/src/home_robot_hw/setup.py
@@ -2,17 +2,14 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from setuptools import setup
+from setuptools import setup, find_packages
 
 install_requires = ["numpy", "empy", "catkin_pkg", "rospkg"]
 
 setup(
     name="home_robot_hw",
     version="1.0.0",
-    packages=["home_robot_hw"],
-    package_dir={
-        "": ".",
-    },
+    packages=find_packages(where="."),
     install_requires=install_requires,
-    zip_safe=False,
+    include_package_data=True,
 )

--- a/src/home_robot_sim/setup.py
+++ b/src/home_robot_sim/setup.py
@@ -2,8 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-import os
-from setuptools import setup
+from setuptools import setup, find_packages
 
 install_requires = [
     "numpy",
@@ -18,8 +17,7 @@ install_requires = [
 setup(
     name="home-robot-sim",
     version="0.1.0",
-    packages=["home_robot_sim"],
-    package_dir={"": "."},
+    packages=find_packages(where="."),
     install_requires=install_requires,
-    zip_safe=False,
+    include_package_data=True,
 )


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->

Previous pip installation in non-development mode would result in installation of an empty package.
This change allows Habitat-Lab to directly install home-robot from github.

## Changelog

<!--- Itemized list of changes -->

- Debug `src/home_robot/setup.py`
- Apply the same changes to `setup.py` files in `home_robot_sim`, `home_robot_hw`, and `home_robot_client`

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
