### PR TITLE
[WIP] Navigation baseline with OVMM habitat task spec

### DIFF
--- a/projects/habitat_objectnav/README.md
+++ b/projects/habitat_objectnav/README.md
@@ -19,7 +19,7 @@ conda activate home-robot
 git clone https://github.com/3dlg-hcvc/habitat-sim --branch floorplanner
 cd habitat-sim
 pip install -r requirements.txt
-python setup.py install --headless
+python setup.py install --headless --with-bullet
 # (if the above commands runs out of memory) 
 # python setup.py build_ext --parallel 8 install --headless
 

--- a/projects/habitat_objectnav/config_utils.py
+++ b/projects/habitat_objectnav/config_utils.py
@@ -3,10 +3,15 @@ from typing import Optional, Tuple
 
 import habitat.config.default
 import yaml
-from habitat.config.default import Config
+from omegaconf import DictConfig
+from habitat_baselines.config.default import get_config as get_habitat_config
+import os
 
+def get_config(path: str, opts: Optional[list] = None):
+    config = get_habitat_config(path)
+    return config, ""
 
-def get_config(path: str, opts: Optional[list] = None) -> Tuple[Config, str]:
+def get_config_old(path: str, opts: Optional[list] = None):
     """Get configuration and ensure consistency between configurations
     inherited from the task and defaults and our code's configuration.
 
@@ -14,14 +19,14 @@ def get_config(path: str, opts: Optional[list] = None) -> Tuple[Config, str]:
         path: path to our code's config
         opts: command line arguments overriding the config
     """
-    config = Config()
+    config = DictConfig()
 
     # Start with our code's config
     config.merge_from_file(path)
 
     # Add Habitat's default config and the base task config path specified
     # in our code's config under TASK_CONFIG
-    task_config = Config()
+    task_config = DictConfig()
     task_config.merge_from_other_cfg(habitat.config.default._C)
     task_config.merge_from_file(config.BASE_TASK_CONFIG_PATH)
     config.TASK_CONFIG = task_config

--- a/projects/habitat_objectnav/configs/agent/floorplanner_eval.yaml
+++ b/projects/habitat_objectnav/configs/agent/floorplanner_eval.yaml
@@ -1,5 +1,3 @@
-BASE_TASK_CONFIG_PATH: configs/task/floorplanner_val.yaml
-
 NO_GPU: 1                 # 1: ignore IDs above and run on CPU, 0: run on GPUs with IDs above
 NUM_ENVIRONMENTS: 35      # number of environments (per agent process)
 DUMP_LOCATION: datadump   # path to dump models and log

--- a/projects/habitat_objectnav/eval_episode.py
+++ b/projects/habitat_objectnav/eval_episode.py
@@ -18,19 +18,25 @@ from home_robot.agent.objectnav_agent.objectnav_agent import ObjectNavAgent
 from home_robot_sim.env.habitat_objectnav_env.habitat_objectnav_env import (
     HabitatObjectNavEnv,
 )
+from omegaconf import  OmegaConf, DictConfig
 
 if __name__ == "__main__":
-    config_path = "configs/agent/floorplanner_eval.yaml"
+    config_path = "rearrange/modular_nav.yaml"
     config, config_str = get_config(config_path)
-    config.defrost()
-    config.NUM_ENVIRONMENTS = 1
-    config.PRINT_IMAGES = 1
-    config.TASK_CONFIG.DATASET.SPLIT = "val"
-    config.EXP_NAME = "debug"
-    config.freeze()
+    OmegaConf.set_readonly(config, False)
+
+    config.habitat_baselines.num_environments = 1
+    OmegaConf.set_struct(config.habitat_baselines,  False)
+    config.habitat_baselines.print_images = 1
+    config.habitat.dataset.split = "val"
+    config.habitat_baselines.exp_name = "debug"
+
+    OmegaConf.set_readonly(config, True)
+    baseline_config = OmegaConf.load('projects/habitat_objectnav/configs/agent/floorplanner_eval.yaml')
+    config = DictConfig({**config, **baseline_config})
 
     agent = ObjectNavAgent(config=config)
-    env = HabitatObjectNavEnv(Env(config=config.TASK_CONFIG), config=config)
+    env = HabitatObjectNavEnv(Env(config=config.habitat), config=config)
 
     agent.reset()
     env.reset()

--- a/src/home_robot/home_robot/agent/objectnav_agent/objectnav_agent.py
+++ b/src/home_robot/home_robot/agent/objectnav_agent/objectnav_agent.py
@@ -18,7 +18,7 @@ from .objectnav_agent_module import ObjectNavAgentModule
 class ObjectNavAgent(Agent):
     def __init__(self, config, device_id: int = 0):
         self.max_steps = config.AGENT.max_steps
-        self.num_environments = config.NUM_ENVIRONMENTS
+        self.num_environments = config.habitat_baselines.num_environments
         if config.AGENT.panorama_start:
             self.panorama_start_steps = int(360 / config.ENVIRONMENT.turn_angle)
         else:

--- a/src/home_robot_sim/home_robot_sim/env/habitat_objectnav_env/visualizer.py
+++ b/src/home_robot_sim/home_robot_sim/env/habitat_objectnav_env/visualizer.py
@@ -28,7 +28,7 @@ class Visualizer:
         self.default_vis_dir = f"{config.DUMP_LOCATION}/images/{config.EXP_NAME}"
         os.makedirs(self.default_vis_dir, exist_ok=True)
 
-        self.episodes_data_path = config.TASK_CONFIG.DATASET.DATA_PATH
+        self.episodes_data_path = config.habitat.dataset.data_path
         assert (
             "floorplanner" in self.episodes_data_path
             or "hm3d" in self.episodes_data_path


### PR DESCRIPTION
## Motivation and Context
 1. Using OVMM task spec on habitat-lab to load episodes
 2. Work habitat-lab v0.2.3 (hydra) configs 
 
TODOs
- [] Separate Env for obs_preprocess functions etc (different from ObjectNav's Env)
- [] Finalize planner outputs (waypoint) and actions (teleport)
- [] Add habitat-lab changes to object_rearrange branch
- [] Update instructions

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->

## Changelog

<!--- Itemized list of changes -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes
`python projects/habitat_objectnav/eval_episode.py`

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
