### PR TITLE
Fix intermittent starvation issue in camera node

### DIFF
--- a/src/home_robot_hw/home_robot_hw/ros/camera.py
+++ b/src/home_robot_hw/home_robot_hw/ros/camera.py
@@ -67,7 +67,7 @@ class RosCamera(Camera):
                     # Wait until we have a full buffer
                     if len(self._buffer) >= self.buffer_size:
                         break
-                rate.sleep()
+            rate.sleep()
 
     def get(self, device=None):
         """return the current image associated with this camera"""


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->

When trying to run experiments I noticed that sometimes the program would hang forever while waiting for depth images.
Turns out `RosCamera.wait_for_images()` was spinning while holding on to the lock required to parse images, and thus either no images were able to be parsed, or that `wait_for_images` was unable to re-acquire the lock and finish the wait after the images arrived.

## Changelog

<!--- Itemized list of changes -->

- Release lock before sleeping

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [x] I ran `tests/hw_manual_test.py` on hardware and observed that robot behavior looks normal.