### PR TITLE
Enable linting for certain parts of home_robot_hw

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,8 @@ repos:
         args: [--install-types, --non-interactive, --no-strict-optional, --ignore-missing-imports]
         exclude: |
             (?x)^(
+                src/home_robot_hw/home_robot_hw/ros/|
+                src/home_robot_hw/home_robot_hw/teleop/|
                 projects/|
             )|setup.py$
 
@@ -26,6 +28,8 @@ repos:
       - id: flake8
         exclude: |
             (?x)^(
+                src/home_robot_hw/home_robot_hw/ros/|
+                src/home_robot_hw/home_robot_hw/teleop/|
                 src/home_robot/home_robot/utils/data_tools/|
                 projects/|
                 tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,6 @@ repos:
         args: [--install-types, --non-interactive, --no-strict-optional, --ignore-missing-imports]
         exclude: |
             (?x)^(
-                src/home_robot_hw/|
                 projects/|
             )|setup.py$
 
@@ -27,7 +26,6 @@ repos:
       - id: flake8
         exclude: |
             (?x)^(
-                src/home_robot_hw/|
                 src/home_robot/home_robot/utils/data_tools/|
                 projects/|
                 tests/

--- a/src/home_robot_hw/home_robot_hw/env/stretch_abstract_env.py
+++ b/src/home_robot_hw/home_robot_hw/env/stretch_abstract_env.py
@@ -1,3 +1,4 @@
+import sys
 import threading
 import time
 import timeit

--- a/src/home_robot_hw/home_robot_hw/env/visualizer.py
+++ b/src/home_robot_hw/home_robot_hw/env/visualizer.py
@@ -156,14 +156,15 @@ class Visualizer:
         # Goal
         if visualize_goal:
             selem = skimage.morphology.disk(4)
-            goal_mat = 1 - skimage.morphology.binary_dilation(goal_map, selem) != True
+            goal_mat = (
+                1 - skimage.morphology.binary_dilation(goal_map, selem)
+            ) is not True
             goal_mask = goal_mat == 1
             semantic_map[goal_mask] = 5
             if closest_goal_map is not None:
                 closest_goal_mat = (
                     1 - skimage.morphology.binary_dilation(closest_goal_map, selem)
-                    != True
-                )
+                ) is not True
                 closest_goal_mask = closest_goal_mat == 1
                 semantic_map[closest_goal_mask] = 4
 

--- a/src/home_robot_hw/home_robot_hw/nodes/state_estimator.py
+++ b/src/home_robot_hw/home_robot_hw/nodes/state_estimator.py
@@ -95,11 +95,11 @@ class NavStateEstimator:
         output[t] = coeff * output[t-1] + (1 - coeff) * input[t]
         ```
 
-        In the high pass filter case, we are injecting the output signal with the difference 
-        between measurements, while in the low pass filter case, we are injecting the output 
-        signal with the absolute value of the measurements. 
+        In the high pass filter case, we are injecting the output signal with the difference
+        between measurements, while in the low pass filter case, we are injecting the output
+        signal with the absolute value of the measurements.
 
-        Slightly hand-wavy way of fusing the two filters to process the signals by simply adding 
+        Slightly hand-wavy way of fusing the two filters to process the signals by simply adding
         together the injected signals of both slam + LPF and odom + HPF into the output pose:
         ```
         output_pose[t] = coeff * output_pose[t-1] \

--- a/src/home_robot_hw/home_robot_hw/stretch_client/modules/head.py
+++ b/src/home_robot_hw/home_robot_hw/stretch_client/modules/head.py
@@ -9,6 +9,7 @@ import rospy
 import trimesh.transformations as tra
 
 from home_robot.motion.robot import Robot
+from home_robot.motion.stretch import HelloStretchIdx
 
 from .abstract import AbstractControlModule
 

--- a/src/home_robot_hw/scripts/interactive_marker.py
+++ b/src/home_robot_hw/scripts/interactive_marker.py
@@ -40,7 +40,11 @@ from geometry_msgs.msg import Point, Quaternion
 from interactive_markers.interactive_marker_server import InteractiveMarkerServer
 from interactive_markers.menu_handler import MenuHandler
 from tf.broadcaster import TransformBroadcaster
-from visualization_msgs.msg import *
+from visualization_msgs.msg import (
+    InteractiveMarker,
+    InteractiveMarkerControl,
+    InteractiveMarkerFeedback,
+)
 
 from home_robot.hw.ros.path import get_package_path
 
@@ -107,7 +111,6 @@ class InteractiveMarkerManager(object):
         self.writer = self.get_writer()
 
         self.server = InteractiveMarkerServer("demo_control")
-        rate = rospy.Rate(10)
 
         pose_mat, curr_q = self.get_current_pose()
 


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->

Previously linters were excluded from the entire `home_robot_hw` due to the sheer amount of legacy code (#57)
 #77 introduces a large chunk of code within `home_robot_hw.stretch_client`.
 To prevent bugs from creeping in, it's best to re-enable linters for as much of home_robot_hw as we conveniently can for now.

## Changelog

<!--- Itemized list of changes -->

- Re-enable linters for certain directories of `home_robot_hw` in the pre-commit config
- Clean up code to comply with linters

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] I ran `tests/hw_manual_test.py` on hardware and observed that robot behavior looks normal.