### PR TITLE
Relatively small tweaks to some point cloud utils to make them torch-compatible

### DIFF
--- a/src/home_robot/home_robot/utils/image.py
+++ b/src/home_robot/home_robot/utils/image.py
@@ -82,7 +82,12 @@ class Camera(object):
         return xyz
 
     def fix_depth(self, depth):
-        depth = depth.copy()
+        if isinstance(depth, np.ndarray):
+            depth = depth.copy()
+        else:
+            # Assuming it's a torch tensor instead
+            depth = depth.clone()
+
         depth[depth > self.far_val] = 0
         depth[depth < self.near_val] = 0
         return depth

--- a/src/home_robot/home_robot/utils/point_cloud_torch.py
+++ b/src/home_robot/home_robot/utils/point_cloud_torch.py
@@ -4,8 +4,6 @@ to allow operations to be done on the GPU for speed.
 """
 import cv2
 import numpy as np
-import open3d as o3d
-import trimesh.transformations as tra
 import torch
 from torch_geometric.nn.pool.voxel_grid import voxel_grid
 from home_robot.utils.image import Camera
@@ -115,7 +113,11 @@ def dropout_random_ellipses(
     return depth_img
 
 
-def grid_pool_point_cloud(unbatched_xyz, unbatched_batch_ids, voxel_size, use_random_centers=False):
+def grid_pool_point_cloud(unbatched_xyz, unbatched_batch_ids, voxel_size, use_random_centers=True):
+    """
+    Overlays a grid, and selects one point in each grid cell (if one exists). If use_random_centers is True,
+    the point selected is random within that cell. Otherwise it's whichever voxel_grid returns first.
+    """
     # Voxel grid returns a list, same length as the original, with a mapping to unique grid identifiers
     xyz_grid_indices = voxel_grid(unbatched_xyz, voxel_size, unbatched_batch_ids)
 
@@ -128,7 +130,7 @@ def grid_pool_point_cloud(unbatched_xyz, unbatched_batch_ids, voxel_size, use_ra
     # from that operation, we can use the count maps as indices into the original xyzs, by doing cumsum
     _, xyz_to_grid_id_sort_mapping = torch.sort(xyz_to_grid_id, stable=True)
 
-    if use_random_centers is True:
+    if use_random_centers:
         random_offsets = (torch.rand(grid_cell_counts.shape[0]).to(grid_cell_counts.device) * grid_cell_counts).int()
     else:
         random_offsets = 0

--- a/src/home_robot/home_robot/utils/point_cloud_torch.py
+++ b/src/home_robot/home_robot/utils/point_cloud_torch.py
@@ -8,6 +8,7 @@ import open3d as o3d
 import trimesh.transformations as tra
 import torch
 from torch_geometric.nn.pool.voxel_grid import voxel_grid
+from home_robot.utils.image import Camera
 
 
 def depth_to_xyz(depth, camera: Camera):

--- a/src/home_robot/home_robot/utils/point_cloud_torch.py
+++ b/src/home_robot/home_robot/utils/point_cloud_torch.py
@@ -1,0 +1,140 @@
+"""
+This file contains versions of the helpers in point_cloud.py that use pytorch directly (rather than numpy),
+to allow operations to be done on the GPU for speed.
+"""
+import cv2
+import numpy as np
+import open3d as o3d
+import trimesh.transformations as tra
+import torch
+from torch_geometric.nn.pool.voxel_grid import voxel_grid
+
+
+def depth_to_xyz(depth, camera: Camera):
+    """get depth from numpy using simple pinhole camera model"""
+    indices = np.indices((camera.height, camera.width), dtype=np.float32).transpose(1, 2, 0)
+    z = depth
+
+    # pixel indices start at top-left corner. for these equations, it starts at bottom-left
+    x = torch.tensor(indices[:, :, 1] - camera.px).to(z.device) * (z / camera.fx)
+    y = torch.tensor(indices[:, :, 0] - camera.py).to(z.device) * (z / camera.fy)
+
+    # Should now be batch x height x width x 3, after this:
+    xyz = torch.stack([x, y, z], axis=-1)
+    return xyz
+
+
+def add_additive_noise_to_xyz(
+    xyz_img,
+    gp_rescale_factor_range=[12, 20],
+    gaussian_scale_range=[0.0, 0.003],
+    valid_mask=None,
+    inplace=False,
+):
+    """
+    Add (approximate) Gaussian Process noise to ordered point cloud
+    @param xyz_img: a [H x W x 3] ordered point cloud
+    """
+    if not inplace:
+        xyz_img = xyz_img.clone()
+
+    H, W, C = xyz_img.shape
+
+    # Additive noise: Gaussian process, approximated by zero-mean anisotropic Gaussian random variable,
+    #                 which is rescaled with bicubic interpolation.
+    gp_rescale_factor = np.random.randint(
+        gp_rescale_factor_range[0], gp_rescale_factor_range[1]
+    )
+    gp_scale = np.random.uniform(gaussian_scale_range[0], gaussian_scale_range[1])
+
+    small_H, small_W = (np.array([H, W]) / gp_rescale_factor).astype(int)
+    additive_noise = np.random.normal(
+        loc=0.0, scale=gp_scale, size=(small_H, small_W, C)
+    )
+    additive_noise = cv2.resize(additive_noise, (W, H), interpolation=cv2.INTER_CUBIC)
+    additive_noise = torch.tensor(additive_noise).to(xyz_img.device)
+    if valid_mask is not None:
+        xyz_img[valid_mask, :] += additive_noise[valid_mask, :]
+    else:
+        xyz_img += additive_noise
+
+    return xyz_img
+
+
+def dropout_random_ellipses(
+    depth_img, dropout_mean, gamma_shape=10000, gamma_scale=0.0001, inplace=False
+):
+    """Randomly drop a few ellipses in the image for robustness.
+    This is adapted from the DexNet 2.0 code.
+    Their code: https://github.com/BerkeleyAutomation/gqcnn/blob/75040b552f6f7fb264c27d427b404756729b5e88/gqcnn/sgd_optimizer.py
+    @param depth_img: a [H x W] set of depth z values
+    """
+    if not inplace:
+        depth_img = depth_img.clone()
+
+    # Sample number of ellipses to dropout
+    num_ellipses_to_dropout = np.random.poisson(dropout_mean)
+
+    # Sample ellipse centers
+    nonzero_pixel_indices = torch.stack(torch.where(depth_img > 0)).T  # Shape: [#nonzero_pixels x 2]
+    dropout_centers_indices = np.random.choice(
+        nonzero_pixel_indices.shape[0], size=num_ellipses_to_dropout
+    )
+    dropout_centers = nonzero_pixel_indices[
+        dropout_centers_indices, :
+    ]  # Shape: [num_ellipses_to_dropout x 2]
+
+    # Sample ellipse radii and angles
+    x_radii = np.random.gamma(gamma_shape, gamma_scale, size=num_ellipses_to_dropout)
+    y_radii = np.random.gamma(gamma_shape, gamma_scale, size=num_ellipses_to_dropout)
+    angles = np.random.randint(0, 360, size=num_ellipses_to_dropout)
+
+    # Dropout ellipses
+    for i in range(num_ellipses_to_dropout):
+        center = dropout_centers[i, :].cpu().numpy()
+        x_radius = np.round(x_radii[i]).astype(int)
+        y_radius = np.round(y_radii[i]).astype(int)
+        angle = angles[i]
+
+        # dropout the ellipse
+        # mask is always 2d even if input is not
+        mask = np.zeros(depth_img.shape[:2])
+        mask = cv2.ellipse(
+            mask,
+            tuple(center[::-1]),
+            (x_radius, y_radius),
+            angle=angle,
+            startAngle=0,
+            endAngle=360,
+            color=1,
+            thickness=-1,
+        )
+        depth_img[mask == 1] = 0
+
+    return depth_img
+
+
+def grid_pool_point_cloud(unbatched_xyz, unbatched_batch_ids, voxel_size, use_random_centers=False):
+    # Voxel grid returns a list, same length as the original, with a mapping to unique grid identifiers
+    xyz_grid_indices = voxel_grid(unbatched_xyz, voxel_size, unbatched_batch_ids)
+
+    # We wish to take one of each grid identifier, to use as our point
+    # Based on: https://stackoverflow.com/questions/72001505/how-to-get-unique-elements-and-their-firstly-appeared-indices-of-a-pytorch-tenso
+    grid_ids, xyz_to_grid_id, grid_cell_counts = torch.unique(xyz_grid_indices, sorted=True, return_inverse=True,
+                                                              return_counts=True)
+
+    # The grid ids are sorted, and the counts match that sorting. So if we sort xyz_to_grid_id and get the mapping
+    # from that operation, we can use the count maps as indices into the original xyzs, by doing cumsum
+    _, xyz_to_grid_id_sort_mapping = torch.sort(xyz_to_grid_id, stable=True)
+
+    if use_random_centers is True:
+        random_offsets = (torch.rand(grid_cell_counts.shape[0]).to(grid_cell_counts.device) * grid_cell_counts).int()
+    else:
+        random_offsets = 0
+
+    unique_grid_indices = torch.cat((torch.tensor([0]).to(grid_cell_counts.device), grid_cell_counts.cumsum(0)[:-1]),
+                                    axis=0) + random_offsets
+    unique_grid_xyz_indices = xyz_to_grid_id_sort_mapping[unique_grid_indices]
+
+    # We return the indices into the original data, for consistency with fps
+    return unique_grid_xyz_indices


### PR DESCRIPTION
Also an implementation of grid_pool using pytorch. Also unifying the point cloud visualization with what I've been using, per discussion with Chris. One thing it enables is passing in a camera extrinsic so the point cloud visualized is what the camera sees. (Note: it's a little wrong still for my use-case -- I have to manually translate 20cm in y and z to get it to look right. Not sure why. But this is close, anyway.)

Sorry this is 3 changes lumped into one -- the unifying factor is basically "these are my util changes". 

## Motivation and Context

Speeds up computation considerably, by avoiding moving some critical (i.e. large) arrays to cpu to use with numpy. Enables consistent visualization of a point cloud in a more head-on pose.

## Changelog

Mostly new functionality, importable by switching "import home_robot.utils.point_cloud" to "import home_robot.utils.point_cloud_torch". I kept show_point_cloud and show_pcd APIs the same, but augmented the saving to an image.

grid_pool_point_cloud is only in the _torch version though. Let me know if there's somewhere more sensible for this to be.

## How Has This Been Tested

I stepped through the point cloud visualization code. The changes to use torch and grid_pool are actively in use in my repo.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [ N/A? ] I have made changes to existing documentation where needed.
- [ There didn't seem to be existing tests for these utils ] I have added tests that show that the PR is functional.
- [ X - failed due to an issue specific to my robot -- nav isn't launching - working on it now, but I'm pretty sure the code I introduced shouldn't be touched in this code path anyway. ] I ran `tests/hw_manual_test.py` on hardware and observed that robot behavior looks normal.