### PR TITLE
Add a launch file to start a "master" clock on the robot side to avoid time sync issues

### DIFF
--- a/src/home_robot_hw/home_robot_hw/nodes/clock.py
+++ b/src/home_robot_hw/home_robot_hw/nodes/clock.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+import time
+
+import rospy
+from rosgraph_msgs.msg import Clock
+
+
+class MasterClock:
+    def __init__(self, spin_rate=10000):
+        self.spin_rate = spin_rate
+        self._dt = 1.0 / self.spin_rate
+        self._pub = rospy.Publisher("/clock", Clock, queue_size=1)
+        self._t = 0
+
+    def spin(self):
+        while not rospy.is_shutdown():
+            self._pub.publish(rospy.Time(self._t))
+            time.sleep(self._dt)
+            self._t += self._dt
+
+
+if __name__ == "__main__":
+    rospy.init_node("master_clock")
+    MasterClock().spin()

--- a/src/home_robot_hw/home_robot_hw/nodes/clock.py
+++ b/src/home_robot_hw/home_robot_hw/nodes/clock.py
@@ -7,15 +7,20 @@ from rosgraph_msgs.msg import Clock
 
 
 class MasterClock:
-    def __init__(self, spin_rate=10000):
+    def __init__(self, spin_rate=10000, wall_time=True):
         self.spin_rate = spin_rate
+        self.wall_time = wall_time
         self._dt = 1.0 / self.spin_rate
         self._pub = rospy.Publisher("/clock", Clock, queue_size=1)
         self._t = 0
 
     def spin(self):
+        """Spin in a loop while publishing time signal. Because this is the "master" clock used for ROS time thoughout HomeRobot, it must not use ROS sleeps!"""
         while not rospy.is_shutdown():
-            self._pub.publish(rospy.Time(self._t))
+            if self.wall_time:
+                self._pub.publish(rospy.Time(time.time()))
+            else:
+                self._pub.publish(rospy.Time(self._t))
             time.sleep(self._dt)
             self._t += self._dt
 

--- a/src/home_robot_hw/launch/master_clock.launch
+++ b/src/home_robot_hw/launch/master_clock.launch
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<launch>
+	<param name="/use_sim_time" value="true"/>
+	<node name="master_clock" type="clock.py" pkg="home_robot_hw" required="true"/>
+</launch>

--- a/src/home_robot_hw/launch/startup_stretch_hector_slam.launch
+++ b/src/home_robot_hw/launch/startup_stretch_hector_slam.launch
@@ -5,10 +5,12 @@
 	<arg name="teleop_keyboard" default="false"/>
 	<arg name="start_rs_ros" default="true"/>
 	<arg name="start_joy_node" default="false"/>
+	<arg name="publish_master_clock" default="true"/>
 
 	<!-- bring up rviz? -->
-	<param name="/use_sim_time" value="false"/>
+	<!--param name="/use_sim_time" value="true"/-->
 	<arg name="rviz" default="false" doc="whether to show Rviz" />
+	<include file="$(find home_robot_hw)/launch/master_clock.launch" if="$(arg publish_master_clock)"/>
 
 	<!-- STRETCH DRIVER -->
 	<param name="/stretch_driver/broadcast_odom_tf" type="bool" value="false"/>


### PR DESCRIPTION
## Motivation and Context

weird delays and need for ntp server
instead, just use sim time and have robot publish whatever time it thinks it is

## Changelog

<!--- Itemized list of changes -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] I ran `tests/hw_manual_test.py` on hardware and observed that robot behavior looks normal.