### PR TITLE
Objectnav breaking change, remove sophuspy dependency

### DIFF
--- a/projects/habitat_objectnav/eval_dataset.py
+++ b/projects/habitat_objectnav/eval_dataset.py
@@ -58,11 +58,7 @@ if __name__ == "__main__":
     config.NUM_ENVIRONMENTS = 1
     config.PRINT_IMAGES = 1
     config.habitat.dataset.split = "val"
-    if config.habitat.dataset.scene_indices_range is not None:
-        scene_indices_range = config.habitat.dataset.scene_indices_range
-        config.EXP_NAME = os.path.join(
-            config.EXP_NAME, f"{scene_indices_range[0]}_{scene_indices_range[1]}"
-        )
+
     agent = ObjectNavAgent(config=config)
     env = HabitatObjectNavEnv(Env(config=config), config=config)
 

--- a/projects/slap_manipulation/requirements.yml
+++ b/projects/slap_manipulation/requirements.yml
@@ -23,7 +23,6 @@ dependencies:
   - pip:
     - numpy <1.24 # certain deprecated operations were used in other deps
     - scipy
-    - sophuspy
     - opencv-python>=3.3.0
     - pybullet
     - trimesh

--- a/src/home_robot/environment.yml
+++ b/src/home_robot/environment.yml
@@ -16,7 +16,6 @@ dependencies:
   - pip:
     - numpy <1.24 # certain deprecated operations were used in other deps
     - scipy
-    - sophuspy
     - pybullet
     - trimesh
     - pytest

--- a/src/home_robot/requirements.txt
+++ b/src/home_robot/requirements.txt
@@ -1,6 +1,5 @@
 numpy <1.24 # certain deprecated operations were used in other deps
 scipy
-sophuspy
 opencv-python
 pybullet
 trimesh

--- a/src/home_robot/setup.py
+++ b/src/home_robot/setup.py
@@ -14,7 +14,6 @@ install_requires = [
     "pygifsicle",
     "numpy-quaternion",
     "pybind11-global",
-    "sophuspy",
     "trimesh",
     "pin==2.6.17",
 ]

--- a/src/home_robot_hw/environment.yml
+++ b/src/home_robot_hw/environment.yml
@@ -21,7 +21,6 @@ dependencies:
   - pip:
     - numpy <1.24 # certain deprecated operations were used in other deps
     - scipy
-    - sophuspy
     - pybullet
     - trimesh
     - pytest


### PR DESCRIPTION
## Motivation and Context
1. Removed `scene_indices_range` config from `habitat.dataset` on [habitat branch](https://github.com/facebookresearch/habitat-lab/pull/1431/commits/abf88a1aae80830617675a8c4b9701c893a7e8f6). This change is needed to avoid accessing the field.

2. Removed sophuspy dependency: #252 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->

## Changelog

<!--- Itemized list of changes -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] I ran `tests/hw_manual_test.py` on hardware and observed that robot behavior looks normal.