### PR TITLE
add back sophuspy dependency

### DIFF
--- a/projects/slap_manipulation/requirements.yml
+++ b/projects/slap_manipulation/requirements.yml
@@ -23,6 +23,7 @@ dependencies:
   - pip:
     - numpy <1.24 # certain deprecated operations were used in other deps
     - scipy
+    - sophuspy
     - opencv-python>=3.3.0
     - pybullet
     - trimesh

--- a/src/home_robot/environment.yml
+++ b/src/home_robot/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - pip:
     - numpy <1.24 # certain deprecated operations were used in other deps
     - scipy
+    - sophuspy
     - pybullet
     - trimesh
     - pytest

--- a/src/home_robot/requirements.txt
+++ b/src/home_robot/requirements.txt
@@ -1,5 +1,6 @@
 numpy <1.24 # certain deprecated operations were used in other deps
 scipy
+sophuspy
 opencv-python
 pybullet
 trimesh

--- a/src/home_robot/setup.py
+++ b/src/home_robot/setup.py
@@ -14,6 +14,7 @@ install_requires = [
     "pygifsicle",
     "numpy-quaternion",
     "pybind11-global",
+    "sophuspy",
     "trimesh",
     "pin==2.6.17",
 ]

--- a/src/home_robot_hw/environment.yml
+++ b/src/home_robot_hw/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   - pip:
     - numpy <1.24 # certain deprecated operations were used in other deps
     - scipy
+    - sophuspy
     - pybullet
     - trimesh
     - pytest


### PR DESCRIPTION
## Motivation and Context

1. sophuspy dependency got removed in previous commit that was merged to main

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->

## Changelog

<!--- Itemized list of changes -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] I ran `tests/hw_manual_test.py` on hardware and observed that robot behavior looks normal.