### PR TITLE
Remove episode argument in agent reset [needs hw test]

### DIFF
--- a/projects/habitat_ovmm/evaluator.py
+++ b/projects/habitat_ovmm/evaluator.py
@@ -76,7 +76,7 @@ class OVMMEvaluator(PPOTrainer):
         """
         Sets vis_dir for storing planner's debug visualisations
         """
-        if hasattr(agent, 'planner'):
+        if hasattr(agent, "planner"):
             agent.planner.set_vis_dir(
                 current_episode.scene_id.split("/")[-1].split(".")[0],
                 current_episode.episode_id,

--- a/projects/real_world_ovmm/eval_episode.py
+++ b/projects/real_world_ovmm/eval_episode.py
@@ -71,6 +71,8 @@ def main(
         robot.nav.navigate_to([0, 0, 0])
 
     agent.reset()
+    if hasattr(agent, 'planner'):
+        agent.planner.set_vis_dir("real_world", now.strftime("%Y_%m_%d_%H_%M_%S"))
     env.reset(start_recep, pick_object, goal_recep)
 
     t = 0

--- a/projects/real_world_ovmm/eval_episode.py
+++ b/projects/real_world_ovmm/eval_episode.py
@@ -71,7 +71,7 @@ def main(
         robot.nav.navigate_to([0, 0, 0])
 
     agent.reset()
-    if hasattr(agent, 'planner'):
+    if hasattr(agent, "planner"):
         agent.planner.set_vis_dir("real_world", now.strftime("%Y_%m_%d_%H_%M_%S"))
     env.reset(start_recep, pick_object, goal_recep)
 

--- a/src/home_robot/home_robot/agent/ovmm_agent/ovmm_agent.py
+++ b/src/home_robot/home_robot/agent/ovmm_agent/ovmm_agent.py
@@ -144,18 +144,10 @@ class OpenVocabManipAgent(ObjectNavAgent):
         info = {**info, **get_skill_as_one_hot_dict(self.states[0].item())}
         return info
 
-    def reset_vectorized(self, episodes=None):
+    def reset_vectorized(self):
         """Initialize agent state."""
         super().reset_vectorized()
 
-        if episodes is None:
-            now = datetime.now()
-            self.planner.set_vis_dir("real_world", now.strftime("%Y_%m_%d_%H_%M_%S"))
-        else:
-            self.planner.set_vis_dir(
-                episodes[0].scene_id.split("/")[-1].split(".")[0],
-                episodes[0].episode_id,
-            )
         if self.gaze_agent is not None:
             self.gaze_agent.reset_vectorized()
         if self.nav_to_obj_agent is not None:
@@ -176,7 +168,7 @@ class OpenVocabManipAgent(ObjectNavAgent):
     def get_nav_to_recep(self):
         return (self.states == Skill.NAV_TO_REC).float().to(device=self.device)
 
-    def reset_vectorized_for_env(self, e: int, episode):
+    def reset_vectorized_for_env(self, e: int):
         """Initialize agent state for a specific environment."""
         self.states[e] = Skill.NAV_TO_OBJ
         self.place_start_step[e] = 0
@@ -190,9 +182,6 @@ class OpenVocabManipAgent(ObjectNavAgent):
         if self.config.AGENT.SKILLS.PICK.type == "heuristic":
             self.pick_policy.reset()
         super().reset_vectorized_for_env(e)
-        self.planner.set_vis_dir(
-            episode.scene_id.split("/")[-1].split(".")[0], episode.episode_id
-        )
         if self.gaze_agent is not None:
             self.gaze_agent.reset_vectorized_for_env(e)
         if self.nav_to_obj_agent is not None:

--- a/src/home_robot/home_robot/agent/ovmm_agent/random_agent.py
+++ b/src/home_robot/home_robot/agent/ovmm_agent/random_agent.py
@@ -44,12 +44,12 @@ class RandomAgent(Agent):
         self.timestep = 0
         pass
 
-    def reset_vectorized(self, episodes=None):
+    def reset_vectorized(self):
         """Initialize agent state."""
         self.timestep = 0
         pass
 
-    def reset_vectorized_for_env(self, e: int, episodes=None):
+    def reset_vectorized_for_env(self, e: int):
         """Initialize agent state for a specific environment."""
         self.timestep = 0
         pass


### PR DESCRIPTION
## Motivation and Context

1. Episode was being passed to agent reset for setting planner vis_dir 
2. Set planner vis dir in eval loop for sim/real
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->

## Changelog

<!--- Itemized list of changes -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] I ran `tests/hw_manual_test.py` on hardware and observed that robot behavior looks normal.