### PR TITLE
Conditionally import habitat dependencies

### DIFF
--- a/src/home_robot/home_robot/agent/ovmm_agent/ovmm_agent.py
+++ b/src/home_robot/home_robot/agent/ovmm_agent/ovmm_agent.py
@@ -17,7 +17,6 @@ from home_robot.agent.ovmm_agent.ovmm_perception import (
     build_vocab_from_category_map,
     read_category_map_file,
 )
-from home_robot.agent.ovmm_agent.ppo_agent import PPOAgent
 from home_robot.core.interfaces import DiscreteNavigationAction, Observations
 from home_robot.manipulation import HeuristicPickPolicy, HeuristicPlacePolicy
 from home_robot.perception.constants import RearrangeBasicCategories
@@ -86,6 +85,8 @@ class OpenVocabManipAgent(ObjectNavAgent):
                 config, self.device, verbose=self.verbose
             )
         elif config.AGENT.SKILLS.PLACE.type == "rl" and not self.skip_skills.place:
+            from home_robot.agent.ovmm_agent.ppo_agent import PPOAgent
+
             self.place_agent = PPOAgent(
                 config,
                 config.AGENT.SKILLS.PLACE,
@@ -93,6 +94,8 @@ class OpenVocabManipAgent(ObjectNavAgent):
             )
         skip_both_gaze = self.skip_skills.gaze_at_obj and self.skip_skills.gaze_at_rec
         if config.AGENT.SKILLS.GAZE_OBJ.type == "rl" and not skip_both_gaze:
+            from home_robot.agent.ovmm_agent.ppo_agent import PPOAgent
+
             self.gaze_agent = PPOAgent(
                 config,
                 config.AGENT.SKILLS.GAZE_OBJ,
@@ -102,6 +105,8 @@ class OpenVocabManipAgent(ObjectNavAgent):
             config.AGENT.SKILLS.NAV_TO_OBJ.type == "rl"
             and not self.skip_skills.nav_to_obj
         ):
+            from home_robot.agent.ovmm_agent.ppo_agent import PPOAgent
+
             self.nav_to_obj_agent = PPOAgent(
                 config,
                 config.AGENT.SKILLS.NAV_TO_OBJ,
@@ -111,6 +116,8 @@ class OpenVocabManipAgent(ObjectNavAgent):
             config.AGENT.SKILLS.NAV_TO_REC.type == "rl"
             and not self.skip_skills.nav_to_rec
         ):
+            from home_robot.agent.ovmm_agent.ppo_agent import PPOAgent
+
             self.nav_to_rec_agent = PPOAgent(
                 config,
                 config.AGENT.SKILLS.NAV_TO_REC,

--- a/src/home_robot/home_robot/agent/ovmm_agent/pick_and_place_agent.py
+++ b/src/home_robot/home_robot/agent/ovmm_agent/pick_and_place_agent.py
@@ -137,8 +137,8 @@ class PickAndPlaceAgent(OpenVocabManipAgent):
         task_info = obs.task_observations
         # Recep goal is unused by our object nav policies
         obs.task_observations["recep_goal"] = None
-        obs.task_observations["start_recep_goal"] = task_info["start_recep_id"]
-        obs.task_observations["object_goal"] = task_info["object_id"]
+        obs.task_observations["start_recep_goal"] = task_info["start_recep_goal"]
+        obs.task_observations["object_goal"] = task_info["object_goal"]
         obs.task_observations["goal_name"] = task_info["object_name"]
         return obs
 
@@ -148,7 +148,7 @@ class PickAndPlaceAgent(OpenVocabManipAgent):
         """Process information we need for the place skills."""
         task_info = obs.task_observations
         # Receptacle goal used for placement
-        obs.task_observations["end_recep_goal"] = task_info["place_recep_id"]
+        obs.task_observations["end_recep_goal"] = task_info["end_recep_goal"]
         # Start receptacle goal unused
         obs.task_observations["start_recep_goal"] = None
         # Object goal unused - we already presumably have it in our hands

--- a/src/home_robot/home_robot/agent/ovmm_agent/pick_and_place_agent.py
+++ b/src/home_robot/home_robot/agent/ovmm_agent/pick_and_place_agent.py
@@ -16,7 +16,6 @@ from home_robot.agent.ovmm_agent.ovmm_perception import (
     build_vocab_from_category_map,
     read_category_map_file,
 )
-from home_robot.agent.ovmm_agent.ppo_agent import PPOAgent
 from home_robot.core.abstract_agent import Agent
 from home_robot.core.interfaces import Action, DiscreteNavigationAction, Observations
 from home_robot.manipulation import HeuristicPlacePolicy
@@ -100,6 +99,8 @@ class PickAndPlaceAgent(OpenVocabManipAgent):
             continuous_angle_tolerance=continuous_angle_tolerance,
         )
         if not self.skip_gaze and hasattr(self.config.AGENT.SKILLS, "GAZE"):
+            from home_robot.agent.ovmm_agent.ppo_agent import PPOAgent
+
             self.gaze_agent = PPOAgent(
                 config,
                 config.AGENT.SKILLS.GAZE,

--- a/src/home_robot/home_robot/perception/constants.py
+++ b/src/home_robot/home_robot/perception/constants.py
@@ -10,8 +10,6 @@ from typing import Tuple
 
 import numpy as np
 import pandas as pd
-from habitat.core.env import Env
-from habitat_sim.utils.common import d3_40_colors_rgb
 
 from home_robot.utils.constants import (
     MAX_DEPTH_REPLACEMENT_VALUE,
@@ -21,6 +19,56 @@ from home_robot.utils.constants import (
 hm3d_to_mp3d_path = Path(__file__).resolve().parent / "matterport_category_mappings.tsv"
 df = pd.read_csv(hm3d_to_mp3d_path, sep="    ", header=0, engine="python")
 hm3d_to_mp3d = {row["category"]: row["mpcat40index"] for _, row in df.iterrows()}
+
+
+# Color constants we use.
+# Note: originally from Habitat
+# from habitat_sim.utils.common import d3_40_colors_rgb
+d3_40_colors_rgb: np.ndarray = np.array(
+    [
+        [31, 119, 180],
+        [174, 199, 232],
+        [255, 127, 14],
+        [255, 187, 120],
+        [44, 160, 44],
+        [152, 223, 138],
+        [214, 39, 40],
+        [255, 152, 150],
+        [148, 103, 189],
+        [197, 176, 213],
+        [140, 86, 75],
+        [196, 156, 148],
+        [227, 119, 194],
+        [247, 182, 210],
+        [127, 127, 127],
+        [199, 199, 199],
+        [188, 189, 34],
+        [219, 219, 141],
+        [23, 190, 207],
+        [158, 218, 229],
+        [57, 59, 121],
+        [82, 84, 163],
+        [107, 110, 207],
+        [156, 158, 222],
+        [99, 121, 57],
+        [140, 162, 82],
+        [181, 207, 107],
+        [206, 219, 156],
+        [140, 109, 49],
+        [189, 158, 57],
+        [231, 186, 82],
+        [231, 203, 148],
+        [132, 60, 57],
+        [173, 73, 74],
+        [214, 97, 107],
+        [231, 150, 156],
+        [123, 65, 115],
+        [165, 81, 148],
+        [206, 109, 189],
+        [222, 158, 214],
+    ],
+    dtype=np.uint8,
+)
 
 
 class SemanticCategoryMapping(ABC):
@@ -38,7 +86,8 @@ class SemanticCategoryMapping(ABC):
         pass
 
     @abstractmethod
-    def reset_instance_id_to_category_id(self, env: Env):
+    def reset_instance_id_to_category_id(self, env):
+        """Reset instance id. Env should be a simulation environment."""
         pass
 
     @property
@@ -253,7 +302,8 @@ class HM3DtoCOCOIndoor(SemanticCategoryMapping):
             self.hm3d_goal_id_to_coco_goal_name[goal_id],
         )
 
-    def reset_instance_id_to_category_id(self, env: Env):
+    def reset_instance_id_to_category_id(self, env):
+
         self._instance_id_to_category_id = np.array(
             [
                 mp3d_to_coco.get(
@@ -462,7 +512,7 @@ class FloorplannertoMukulIndoor(SemanticCategoryMapping):
     def map_goal_id(self, goal_id: int) -> Tuple[int, str]:
         return (goal_id, self.floorplanner_goal_id_to_goal_name[goal_id])
 
-    def reset_instance_id_to_category_id(self, env: Env):
+    def reset_instance_id_to_category_id(self, env):
         # Identity everywhere except index 0 mapped to 34
         self._instance_id_to_category_id = np.arange(self.num_sem_categories)
         self._instance_id_to_category_id[0] = self.num_sem_categories - 1
@@ -587,7 +637,8 @@ class HM3DtoHSSD28Indoor(SemanticCategoryMapping):
     def map_goal_id(self, goal_id: int) -> Tuple[int, str]:
         return (goal_id, self.floorplanner_goal_id_to_goal_name[goal_id])
 
-    def reset_instance_id_to_category_id(self, env: Env):
+    def reset_instance_id_to_category_id(self, env):
+        """Reset habitat instance ids. Env should be a simulation environment."""
         pass
 
     @property
@@ -621,7 +672,8 @@ class RearrangeBasicCategories(SemanticCategoryMapping):
     def map_goal_id(self, goal_id: int) -> Tuple[int, str]:
         return (goal_id, self.goal_id_to_goal_name[goal_id])
 
-    def reset_instance_id_to_category_id(self, env: Env):
+    def reset_instance_id_to_category_id(self, env=None):
+        """Reset instance IDs in habitat environments. Env should be a habitat env."""
         # Identity everywhere except index 0 mapped to 4
         self._instance_id_to_category_id = np.arange(self.num_sem_categories)
         self._instance_id_to_category_id[0] = self.num_sem_categories - 1
@@ -666,7 +718,8 @@ class RearrangeDETICCategories(SemanticCategoryMapping):
     def map_goal_id(self, goal_id: int) -> Tuple[int, str]:
         return (goal_id, self.goal_id_to_goal_name[goal_id])
 
-    def reset_instance_id_to_category_id(self, env: Env):
+    def reset_instance_id_to_category_id(self, env=None):
+        """Reset instance Ids."""
         self._instance_id_to_category_id = np.arange(self.num_sem_categories)
         self._instance_id_to_category_id[0] = self.num_sem_categories - 1
 
@@ -1635,7 +1688,8 @@ class HM3DtoLongTailIndoor(SemanticCategoryMapping):
             self.hm3d_goal_id_to_longtail_goal_name[goal_id],
         )
 
-    def reset_instance_id_to_category_id(self, env: Env):
+    def reset_instance_id_to_category_id(self, env):
+        """Reset instance IDs from semantic annotations. Env here should be a simulation env from habitat."""
         self._instance_id_to_category_id = np.ndarray(
             [
                 long_tail_indoor_categories.index(


### PR DESCRIPTION
## Motivation and Context

- Make sure that you can run heuristic policies without Habitat Sim being installed
- This makes it easier for people to train without installing sim on their robot workstation

## Changelog

<!--- Itemized list of changes -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] I ran `tests/hw_manual_test.py` on hardware and observed that robot behavior looks normal.