### PR TITLE
docs: fix link to training DD-PPO skills

### DIFF
--- a/docs/challenge.md
+++ b/docs/challenge.md
@@ -125,6 +125,6 @@ The challenge consists of the following phases:
 Simulation agents will be evaluated on an AWS EC2 p2.xlarge instance which has a Tesla K80 GPU (12 GB Memory), 4 CPU cores, and 61 GB RAM. Agents will be evaluated on 1000 episodes and will have a total available time of 48 hours to finish each run. If you need more time/resources for evaluation of your submission please get in touch. If you face any issues or have questions you can ask them by opening an issue on this repository.
 
 ### DD-PPO Training Starter Code
-Please refer to the Training DD-PPO skills section of the [Habitat OVMM readme](projects/habitat_ovmm/README.md#training-dd-ppo-skills) for more details.
+Please refer to the Training DD-PPO skills section of the [Habitat OVMM readme](../projects/habitat_ovmm/README.md#training-dd-ppo-skills) for more details.
 
 


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The relative path to documentation is broken around training DD-PPO skills in the Habitat simulator.

<!--- Please link to an existing issue here if one exists. -->

## Changelog

<!--- Itemized list of changes -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Link is valid.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [x ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] I ran `tests/hw_manual_test.py` on hardware and observed that robot behavior looks normal.