### PR TITLE
OVMM: Shortest Path Follower Example (Nav to Object)

### DIFF
--- a/projects/habitat_ovmm/configs/agent/oracle_agent.yaml
+++ b/projects/habitat_ovmm/configs/agent/oracle_agent.yaml
@@ -1,0 +1,169 @@
+max_steps: 10000         # maximum number of steps before stopping an episode during navigation; a lower value set for habitat episode termination 
+panorama_start: 1       # 1: turn around 360 degrees when starting an episode, 0: don't
+exploration_strategy: seen_frontier  # exploration strategy ("seen_frontier", "been_close_to_frontier")
+radius: 0.05            # robot radius (in meters)
+fall_wait_steps: 200    # number of steps to wait after the object has been dropped
+store_all_categories: False  # whether to store all semantic categories in the map or just task-relevant ones
+detection_module: detic # the detector to use for perception in case ground_truth_semantics are turned off
+SEMANTIC_MAP:
+  semantic_categories: rearrange # map semantic channel categories ("coco_indoor", "longtail_indoor", "mukul_indoor", "rearrange")
+  num_sem_categories: 5    # Following 5 categories: ["misc", "object_category", "start_receptacle", "goal_receptacle", "others"]
+  map_size_cm: 4800        # global map size (in centimeters)
+  map_resolution: 5        # size of map bins (in centimeters)
+  vision_range: 100        # diameter of local map region visible by the agent (in cells)
+  global_downscaling: 2    # ratio of global over local map
+  du_scale: 4              # frame downscaling before projecting to point cloud
+  cat_pred_threshold: 1.0  # number of depth points to be in bin to classify it as a certain semantic category
+  exp_pred_threshold: 1.0  # number of depth points to be in bin to consider it as explored
+  map_pred_threshold: 1.0  # number of depth points to be in bin to consider it as obstacle
+  been_close_to_radius: 100  # radius (in centimeters) of been close to region
+  explored_radius: 150       # radius (in centimeters) of visually explored region
+  must_explore_close: False
+  min_obs_height_cm: 10    # minimum height (in centimeters) of obstacle
+  # erosion and filtering to reduce the number of spurious artifacts
+  dilate_obstacles: True
+  dilate_size: 3
+  dilate_iter: 1
+  record_instance_ids: False
+  max_instances: 0
+
+SKILLS:
+  GAZE_OBJ:
+    type: rl #end_to_end #heuristic #hardcoded
+    checkpoint_path: data/checkpoints/ovmm_baseline_home_robot_challenge_2023/gaze_at_obj.pth
+    rl_config: projects/habitat_ovmm/configs/agent/skills/gaze_rl.yaml # with continuous actions
+    gym_obs_keys:
+      - robot_head_depth
+      - object_embedding
+      - object_segmentation
+      - joint
+      - is_holding
+      - relative_resting_position
+    allowed_actions:
+      - arm_action
+      - base_velocity
+    arm_joint_mask: [0, 0, 0, 0, 0, 0, 1] # the arm joints that the policy can control
+    max_displacement: 0.25                     # used when training the policy
+    max_turn_degrees: 30.0
+    min_turn_degrees: 5.0
+    min_displacement: 0.1
+    sensor_height: 160
+    sensor_width: 120
+    nav_goal_seg_channels: 1
+    terminate_condition: grip
+    grip_threshold: 0.8
+    max_joint_delta: 0.1
+    min_joint_delta: 0.02
+
+  PICK:
+    type: heuristic
+
+  NAV_TO_OBJ:
+    type: oracle  # heuristic (default) or rl
+    checkpoint_path: data/checkpoints/ovmm_baseline_home_robot_challenge_2023/nav_to_obj.pth
+    rl_config: projects/habitat_ovmm/configs/agent/skills/nav_to_obj_rl.yaml
+    gym_obs_keys:
+      - robot_head_depth
+      - object_embedding
+      - ovmm_nav_goal_segmentation
+      - receptacle_segmentation
+      - start_receptacle
+      - robot_start_gps
+      - robot_start_compass
+      - joint
+    allowed_actions:
+      # - base_velocity
+      # - rearrange_stop
+      - stop
+      - move_forward
+      - turn_left
+      - turn_right
+    arm_joint_mask: [0, 0, 0, 0, 0, 0, 0] # the arm joints that the policy can control
+    max_displacement: 0.25                # used when training the policy; could be different from the eval values
+    max_turn_degrees: 30.0
+    min_turn_degrees: 5.0
+    min_displacement: 0.1
+    sensor_height: 160
+    sensor_width: 120
+    terminate_condition: discrete_stop
+    nav_goal_seg_channels: 2
+
+  NAV_TO_REC:
+    type: oracle  # heuristic (default) or rl
+    checkpoint_path: data/checkpoints/ovmm_baseline_home_robot_challenge_2023/nav_to_rec.pth
+    rl_config: projects/habitat_ovmm/configs/agent/skills/nav_to_obj_rl.yaml
+    gym_obs_keys:
+      - robot_head_depth
+      - ovmm_nav_goal_segmentation
+      - receptacle_segmentation
+      - goal_receptacle
+      - robot_start_gps
+      - robot_start_compass
+      - joint
+    allowed_actions:
+      # - base_velocity
+      # - rearrange_stop
+      - stop
+      - move_forward
+      - turn_left
+      - turn_right
+    arm_joint_mask: [0, 0, 0, 0, 0, 0, 0] # the arm joints that the policy can control
+    max_displacement: 0.25                # used when training the policy; could be different from the eval values
+    max_turn_degrees: 30.0
+    min_turn_degrees: 5.0
+    min_displacement: 0.1
+    sensor_height: 160
+    sensor_width: 120
+    terminate_condition: discrete_stop
+    nav_goal_seg_channels: 1
+
+
+  PLACE:
+    type: heuristic # "rl" or "heuristic" or "hardcoded"
+    checkpoint_path: data/checkpoints/ovmm_baseline_home_robot_challenge_2023/place.pth
+    rl_config: projects/habitat_ovmm/configs/agent/skills/place_rl.yaml # with continuous actions
+    gym_obs_keys:
+      - robot_head_depth
+      - goal_receptacle
+      - joint
+      - goal_recep_segmentation
+      - is_holding
+      - object_embedding
+    allowed_actions:
+      - arm_action
+      - base_velocity
+      - manipulation_mode
+    arm_joint_mask: [1, 1, 1, 1, 1, 0, 0] # the arm joints that the policy can control
+    max_displacement: 0.25                     # used when training the policy
+    max_turn_degrees: 30.0
+    min_turn_degrees: 5.0
+    min_displacement: 0.1
+    sensor_height: 160
+    sensor_width: 120
+    nav_goal_seg_channels: 1
+    terminate_condition: ungrip
+    grip_threshold: -0.8
+    manip_mode_threshold: 0.8
+    constraint_base_in_manip_mode: True
+    max_joint_delta: 0.1
+    min_joint_delta: 0.02
+
+skip_skills:
+  nav_to_obj: False
+  nav_to_rec: False
+  gaze_at_obj: True
+  gaze_at_rec: True
+  pick: False
+  place: False
+
+PLANNER:
+  collision_threshold: 0.20       # forward move distance under which we consider there's a collision (in meters)
+  obs_dilation_selem_radius: 3    # radius (in cells) of obstacle dilation structuring element
+  goal_dilation_selem_radius: 10  # radius (in cells) of goal dilation structuring element
+  step_size: 5                    # maximum distance of the short-term goal selected by the planner
+  use_dilation_for_stg: False
+  min_obs_dilation_selem_radius: 1    # radius (in cells) of obstacle dilation structuring element
+  map_downsample_factor: 1            # optional downsampling of traversible and goal map before fmm distance call (1 for no downsampling, 2 for halving resolution)
+  map_update_frequency: 1             # compute fmm distance map every n steps 
+  discrete_actions: True         # discrete motion planner output space or not
+  verbose: True                  # display debug information during planning

--- a/projects/habitat_ovmm/configs/env/hssd_eval.yaml
+++ b/projects/habitat_ovmm/configs/env/hssd_eval.yaml
@@ -3,14 +3,14 @@ NUM_ENVIRONMENTS: 1       # number of environments (per agent process)
 DUMP_LOCATION: datadump   # path to dump models and log
 EXP_NAME: eval_hssd       # experiment name
 VISUALIZE: 0              # 1: render observation and predicted semantic map, 0: no visualization
-PRINT_IMAGES: 0           # 1: save visualization as images, 0: no image saving
-GROUND_TRUTH_SEMANTICS: 0 # 1: use ground-truth semantics (for debugging / ablations)
+PRINT_IMAGES: 1           # 1: save visualization as images, 0: no image saving
+GROUND_TRUTH_SEMANTICS: 1 # 1: use ground-truth semantics (for debugging / ablations)
 seed: 0                   # seed
 SHOW_RL_OBS: False         # whether to show the observations passed to RL policices, for debugging
 
 ENVIRONMENT:
-  forward: 0.25           # forward motion (in meters)
-  turn_angle: 30.0        # agent turn angle (in degrees)
+  forward: 0.25           # forward motion (in meters)  Note: changing this should require a corresponding change in the habitat benchmark config
+  turn_angle: 30.0         # agent turn angle (in degrees)  Note: changing this should require a corresponding change in the habitat benchmark config
   frame_height: 640       # first-person frame height (in pixels)
   frame_width: 480        # first-person frame width (in pixels)
   camera_height: 1.31     # camera sensor height (in metres)

--- a/projects/habitat_ovmm/shortest_path_follower_example.py
+++ b/projects/habitat_ovmm/shortest_path_follower_example.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import os
+
+import magnum as mn
+from habitat.core.utils import try_cv2_import
+from habitat.sims.habitat_simulator.actions import HabitatSimActions
+from habitat.tasks.nav.shortest_path_follower import ShortestPathFollower
+from habitat.utils.visualizations import maps
+from habitat.utils.visualizations.utils import images_to_video
+from utils.config_utils import (
+    create_agent_config,
+    create_env_config,
+    get_habitat_config,
+    get_omega_config,
+)
+from utils.env_utils import create_ovmm_env_fn
+
+from home_robot.core.interfaces import DiscreteNavigationAction
+
+cv2 = try_cv2_import()
+
+IMAGE_DIR = os.path.join("examples", "images")
+if not os.path.exists(IMAGE_DIR):
+    os.makedirs(IMAGE_DIR)
+
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+os.environ["NUMEXPR_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+
+DISCRETE_ACTION_MAP = {
+    HabitatSimActions.stop: DiscreteNavigationAction.STOP,
+    HabitatSimActions.move_forward: DiscreteNavigationAction.MOVE_FORWARD,
+    HabitatSimActions.turn_left: DiscreteNavigationAction.TURN_LEFT,
+    HabitatSimActions.turn_right: DiscreteNavigationAction.TURN_RIGHT,
+}
+
+
+def draw_top_down_map(info, output_size):
+    return maps.colorize_draw_agent_and_fit_to_height(info["top_down_map"], output_size)
+
+
+def shortest_path_example(config):
+    """
+    Example script for performing oracle navigation to object in OVMM episodes.
+    Utilizes ShortestPathFollower to output discrete actions in HabitatOpenVocabManipEnv.
+    Note: HabitatOpenVocabManipEnv internally takes care of converting discrete actions to continuous actions.
+    Note: The environment heirarchy above is as follows:
+    ovmm_env
+        HabitatOpenVocabManipEnv
+    ovmm_env.habitat_env
+        GymHabitatEnv<HabGymWrapper instance>
+    ovmm_env.habitat_env.env
+        HabGymWrapper instance
+    ovmm_env.habitat_env.env._env
+        RLTaskEnv instance
+    ovmm_env.habitat_env.env._env._env
+        habitat.core.env.Env
+    ovmm_env.habitat_env.env._env._env.sim
+        OVMMSim
+    """
+    ovmm_env = create_ovmm_env_fn(config)
+    print(f"Total number of episodes in env: {ovmm_env.number_of_episodes}")
+
+    forward_step_size = getattr(config.habitat.simulator, "forward_step_size", None)
+    goal_radius = getattr(config.AGENT, "radius", forward_step_size) * 4
+    if goal_radius < forward_step_size:
+        print(
+            f"Goal radius is smaller than forward step size! Consider increasing the goal radius."
+        )
+
+    follower = ShortestPathFollower(
+        ovmm_env.habitat_env.env._env.habitat_env.sim, goal_radius, False
+    )
+
+    for _ in range(ovmm_env.number_of_episodes):
+        ovmm_env.reset()
+        episode_id = ovmm_env.get_current_episode().episode_id
+        dirname = os.path.join(
+            IMAGE_DIR,
+            "shortest_path_example_ovmm",
+            f"{episode_id}",
+        )
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+        log_file_name = f"logs_ep_{episode_id}.txt"
+
+        with open(os.path.join(os.getcwd(), dirname, log_file_name), "w") as f:
+            f.write("Environment creation successful\n")
+            f.write("Agent stepping around inside environment.\n")
+            images_third_person = []
+            steps, max_steps = 0, 1000
+            info = None
+            object_pos = ovmm_env.habitat_env.env._env.habitat_env.current_episode.candidate_objects[
+                0
+            ].position
+
+            while (
+                not ovmm_env.habitat_env.env._env.habitat_env.episode_over
+                and steps < max_steps
+            ):
+                if steps != 0:
+                    f.write(
+                        f"info['ovmm_dist_to_pick_goal']:\t{info['ovmm_dist_to_pick_goal']}\n"
+                    )
+
+                f.write(f"\nTimestep: {steps}\n")
+                print(f"Timestep: {steps}")
+                best_action = DISCRETE_ACTION_MAP[
+                    follower.get_next_action(mn.Vector3(object_pos), f)
+                ]
+                f.write(f"Agent action: {best_action}\n")
+                if best_action is None:
+                    break
+
+                observations, done, info = ovmm_env.apply_action(best_action, info)
+                steps += 1
+                info["timestep"] = steps
+                if config.PRINT_IMAGES and config.GROUND_TRUTH_SEMANTICS:
+                    images_third_person.append(observations.third_person_image)
+
+            if len(images_third_person):
+                images_to_video(images_third_person, dirname, "trajectory_third_person")
+            if steps >= max_steps:
+                f.write("Max steps reached! Aborting episode...")
+            else:
+                f.write("Episode finished succesfully")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--evaluation_type",
+        type=str,
+        choices=["local", "local_vectorized", "remote"],
+        default="local",
+    )
+    parser.add_argument("--num_episodes", type=int, default=None)
+    parser.add_argument(
+        "--habitat_config_path",
+        type=str,
+        default="ovmm/ovmm_eval.yaml",
+        help="Path to config yaml",
+    )
+    parser.add_argument(
+        "--baseline_config_path",
+        type=str,
+        default="projects/habitat_ovmm/configs/agent/oracle_agent.yaml",
+        help="Path to config yaml",
+    )
+    parser.add_argument(
+        "--env_config_path",
+        type=str,
+        default="projects/habitat_ovmm/configs/env/hssd_eval.yaml",
+        help="Path to config yaml",
+    )
+    parser.add_argument(
+        "--agent_type",
+        type=str,
+        default="baseline",
+        choices=["baseline", "random"],
+        help="Agent to evaluate",
+    )
+    parser.add_argument(
+        "overrides",
+        default=None,
+        nargs=argparse.REMAINDER,
+        help="Modify config options from command line",
+    )
+    args = parser.parse_args()
+
+    # get habitat config
+    habitat_config, _ = get_habitat_config(
+        args.habitat_config_path,
+        overrides=args.overrides
+        + [
+            "+habitat/task/measurements@habitat.task.measurements.top_down_map=top_down_map"
+        ],
+    )
+
+    # get baseline config
+    baseline_config = get_omega_config(args.baseline_config_path)
+
+    # get env config
+    env_config = get_omega_config(args.env_config_path)
+
+    # merge habitat and env config to create env config
+    env_config = create_env_config(
+        habitat_config, env_config, evaluation_type=args.evaluation_type
+    )
+
+    # merge env config and baseline config to create agent config
+    agent_config = create_agent_config(env_config, baseline_config)
+
+    shortest_path_example(agent_config)

--- a/src/home_robot_sim/home_robot_sim/env/habitat_ovmm_env/habitat_ovmm_env.py
+++ b/src/home_robot_sim/home_robot_sim/env/habitat_ovmm_env/habitat_ovmm_env.py
@@ -355,9 +355,10 @@ class HabitatOpenVocabManipEnv(HabitatEnv):
         habitat_action = self._preprocess_action(action, self._last_habitat_obs)
         habitat_obs, _, dones, infos = self.habitat_env.step(habitat_action)
         # copy the keys in info starting with the prefix "is_curr_skill" into infos
-        for key in info:
-            if key.startswith("is_curr_skill"):
-                infos[key] = info[key]
+        if info is not None:
+            for key in info:
+                if key.startswith("is_curr_skill"):
+                    infos[key] = info[key]
         self._last_habitat_obs = habitat_obs
         self._last_obs = self._preprocess_obs(habitat_obs)
         return self._last_obs, dones, infos


### PR DESCRIPTION
## Motivation and Context

Adds an example script to perform shortest path oracle navigation to the first object to be picked up in an OVMM episode 

## Changelog
New script

## How Has This Been Tested
Tested locally with multiple combinations of turn degrees and forward step sizes, across multiple different episodes

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] I ran `tests/hw_manual_test.py` on hardware and observed that robot behavior looks normal.