### PR TITLE
Allow rl eval to use different discrete step

### DIFF
--- a/projects/habitat_ovmm/configs/agent/heuristic_agent.yaml
+++ b/projects/habitat_ovmm/configs/agent/heuristic_agent.yaml
@@ -84,6 +84,8 @@ SKILLS:
     min_turn_degrees: 5.0
     min_displacement: 0.1
     sensor_height: 160
+    discrete_forward: 0.25
+    discrete_turn_degrees: 10
     sensor_width: 120
     terminate_condition: discrete_stop
     nav_goal_seg_channels: 2
@@ -112,6 +114,8 @@ SKILLS:
     max_turn_degrees: 30.0
     min_turn_degrees: 5.0
     min_displacement: 0.1
+    discrete_forward: 0.25
+    discrete_turn_degrees: 10
     sensor_height: 160
     sensor_width: 120
     terminate_condition: discrete_stop

--- a/projects/habitat_ovmm/configs/agent/rl_agent.yaml
+++ b/projects/habitat_ovmm/configs/agent/rl_agent.yaml
@@ -84,6 +84,8 @@ SKILLS:
     max_turn_degrees: 30.0
     min_turn_degrees: 5.0
     min_displacement: 0.1
+    discrete_forward: 0.25
+    discrete_turn_degrees: 10
     sensor_height: 160
     sensor_width: 120
     terminate_condition: discrete_stop
@@ -113,6 +115,8 @@ SKILLS:
     max_turn_degrees: 30.0
     min_turn_degrees: 5.0
     min_displacement: 0.1
+    discrete_forward: 0.25
+    discrete_turn_degrees: 10
     sensor_height: 160
     sensor_width: 120
     terminate_condition: discrete_stop

--- a/src/home_robot/home_robot/agent/ovmm_agent/ppo_agent.py
+++ b/src/home_robot/home_robot/agent/ovmm_agent/ppo_agent.py
@@ -138,7 +138,6 @@ class PPOAgent(Agent):
 
         # actions the skill takes
         self.skill_actions = skill_config.allowed_actions
-
         if self.continuous_actions:
             # filter the action space, deepcopy is necessary because we override arm_action next
             self.filtered_action_space = spaces.Dict(
@@ -208,6 +207,15 @@ class PPOAgent(Agent):
             self.constraint_base_in_manip_mode = (
                 skill_config.constraint_base_in_manip_mode
             )
+        self.discrete_forward = None
+        self.discrete_turn = None
+        if "move_forward" in skill_config.allowed_actions:
+            self.discrete_forward = skill_config.discrete_forward
+        if (
+            "turn_left" in skill_config.allowed_actions
+            or "turn_right" in skill_config.allowed_actions
+        ):
+            self.discrete_turn = skill_config.discrete_turn_degrees * np.pi / 180
         self.terminate_condition = skill_config.terminate_condition
         self.show_rl_obs = getattr(config, "SHOW_RL_OBS", False)
         self.manip_mode_called = False
@@ -463,13 +471,15 @@ class PPOAgent(Agent):
 
     def _map_discrete_habitat_actions(self, discrete_action, skill_actions):
         discrete_action = skill_actions[discrete_action]
+        cont_action = np.array([0.0, 0.0, 0.0])
         if discrete_action == "move_forward":
-            return DiscreteNavigationAction.MOVE_FORWARD
+            cont_action[0] = self.discrete_forward
         elif discrete_action == "turn_left":
-            return DiscreteNavigationAction.TURN_LEFT
+            cont_action[2] = self.discrete_turn
         elif discrete_action == "turn_right":
-            return DiscreteNavigationAction.TURN_RIGHT
+            cont_action[2] = -self.discrete_turn
         elif discrete_action == "stop":
             return DiscreteNavigationAction.STOP
         else:
             raise ValueError
+        return ContinuousNavigationAction(cont_action)


### PR DESCRIPTION
## Motivation and Context

- Allows discrete step for RL eval to be different from the one used in home-robot
- Habitat-lab side changes: options for stricter grasping (disabled by default), fix for https://github.com/facebookresearch/home-robot/issues/332

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->

## Changelog

<!--- Itemized list of changes -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] I ran `tests/hw_manual_test.py` on hardware and observed that robot behavior looks normal.