### PR TITLE
use minival episodes for local docker evaluations

### DIFF
--- a/docs/challenge.md
+++ b/docs/challenge.md
@@ -22,8 +22,8 @@ Make sure you have [Docker](https://docs.docker.com/engine/install/ubuntu/) with
    ```
    cd projects/habitat_ovmm
    ```
-1. Implement your own agent or try our baseline agent, located in [projects/habitat_ovmm/eval_baselines_agent.py](projects/habitat_ovmm/eval_baselines_agent.py). 
-1. Modify the provided [projects/habitat_ovmm/docker/ovmm_baseline.Dockerfile](docker/ovmm_baseline.Dockerfile) if you need custom modifications. Let’s say your code needs `<some extra package>`, this dependency should be pip installed inside a conda environment called `home-robot` that is shipped with our HomeRobot challenge docker, as shown below:
+1. Implement your own agent or try our baseline agent, located in [projects/habitat_ovmm/eval_baselines_agent.py](../projects/habitat_ovmm/eval_baselines_agent.py).
+1. Modify the provided [projects/habitat_ovmm/docker/ovmm_baseline.Dockerfile](../projects/habitat_ovmm/docker/ovmm_baseline.Dockerfile) if you need custom modifications. Let’s say your code needs `<some extra package>`, this dependency should be pip installed inside a conda environment called `home-robot` that is shipped with our HomeRobot challenge docker, as shown below:
     ```dockerfile
     FROM fairembodied/habitat-challenge:homerobot-ovmm-challenge-2023
 
@@ -70,7 +70,7 @@ Make sure you have [Docker](https://docs.docker.com/engine/install/ubuntu/) with
     ```
     *Note 2:* You can modify `submission.sh` file if your agent needs any custom modifications (e.g. command-line arguments). For example, agent type may be changed by changing `--agent_type` (and corresponding `--baseline_config_path`) argument in the `./scripts/test_local.sh` or `projects/habitat_ovmm/eval_baselines_agent.py`. Otherwise, nothing to do. Default submission.sh is simply a call to agent in `agent.py`
 
-   For evaluating an agent taking random actions, build a Docker image using [projects/habitat_ovmm/docker/ovmm_random_agent.Dockerfile](docker/ovmm_random_agent.Dockerfile) as follows:
+   For evaluating an agent taking random actions, build a Docker image using [projects/habitat_ovmm/docker/ovmm_random_agent.Dockerfile](../projects/habitat_ovmm/docker/ovmm_random_agent.Dockerfile) as follows:
 
     ```bash
     docker build . \

--- a/docs/challenge.md
+++ b/docs/challenge.md
@@ -23,7 +23,7 @@ Make sure you have [Docker](https://docs.docker.com/engine/install/ubuntu/) with
    cd projects/habitat_ovmm
    ```
 1. Implement your own agent or try our baseline agent, located in [projects/habitat_ovmm/eval_baselines_agent.py](projects/habitat_ovmm/eval_baselines_agent.py). 
-1. Modify the provided [projects/habitat_ovmm/docker/ovmm_baseline.Dockerfile](projects/habitat_ovmm/docker/ovmm_baseline.Dockerfile) if you need custom modifications. Let’s say your code needs `<some extra package>`, this dependency should be pip installed inside a conda environment called `home-robot` that is shipped with our HomeRobot challenge docker, as shown below: 
+1. Modify the provided [projects/habitat_ovmm/docker/ovmm_baseline.Dockerfile](docker/ovmm_baseline.Dockerfile) if you need custom modifications. Let’s say your code needs `<some extra package>`, this dependency should be pip installed inside a conda environment called `home-robot` that is shipped with our HomeRobot challenge docker, as shown below:
     ```dockerfile
     FROM fairembodied/habitat-challenge:homerobot-ovmm-challenge-2023
 
@@ -70,12 +70,26 @@ Make sure you have [Docker](https://docs.docker.com/engine/install/ubuntu/) with
     ```
     *Note 2:* You can modify `submission.sh` file if your agent needs any custom modifications (e.g. command-line arguments). For example, agent type may be changed by changing `--agent_type` (and corresponding `--baseline_config_path`) argument in the `./scripts/test_local.sh` or `projects/habitat_ovmm/eval_baselines_agent.py`. Otherwise, nothing to do. Default submission.sh is simply a call to agent in `agent.py`
 
+   For evaluating an agent taking random actions, build a Docker image using [projects/habitat_ovmm/docker/ovmm_random_agent.Dockerfile](docker/ovmm_random_agent.Dockerfile) as follows:
+
+    ```bash
+    docker build . \
+        -f docker/ovmm_random_agent.Dockerfile \
+        -t ovmm_random_agent_submission
+    ```
+
 1. Download all the required data into the `home-robot/data` directory (see [Habitat OVMM readme](../projects/habitat_ovmm/README.md)). Then in your `docker run` command mount `home-robot/data` data folder to the `home-robot/data` folder in the Docker image (see `./scripts/test_local.sh` for reference).
      
 1. Evaluate your docker container locally:
     ```bash
-    ./scripts/test_local.sh --docker-name ovmm_baseline_submission
+    ./scripts/test_local.sh --docker-name ovmm_baseline_submission --split minival
     ```
+    Similarly, the random agent can be evaluated locally with:
+
+    ```bash
+    ./scripts/test_local.sh --docker-name ovmm_random_agent_submission --split minival
+    ```
+
     If the above command runs successfully (for the random agent) you will get an output similar to:
     ```
     2023-07-18 21:02:10,607 Initializing dataset OVMMDataset-v0

--- a/projects/habitat_ovmm/docker/ovmm_baseline.Dockerfile
+++ b/projects/habitat_ovmm/docker/ovmm_baseline.Dockerfile
@@ -38,10 +38,13 @@ ADD scripts/submission.sh /home-robot/submission.sh
 # set evaluation type to remote
 ENV AGENT_EVALUATION_TYPE remote
 
+# additional command line arguments for local evaluations (empty for remote evaluation)
+ENV LOCAL_ARGS ""
+
 # run submission script
 CMD /bin/bash -c "\
     . activate home-robot \
     && cd /home-robot \
     && export PYTHONPATH=/evalai_remote_evaluation:$PYTHONPATH \
-    && bash submission.sh \
+    && bash submission.sh $LOCAL_ARGS \
     "

--- a/projects/habitat_ovmm/docker/ovmm_random_agent.Dockerfile
+++ b/projects/habitat_ovmm/docker/ovmm_random_agent.Dockerfile
@@ -46,5 +46,5 @@ CMD /bin/bash -c "\
     . activate home-robot \
     && cd /home-robot \
     && export PYTHONPATH=/evalai_remote_evaluation:$PYTHONPATH \
-    && bash submission.sh $LOCAL_ARGS \
+    && bash submission.sh --agent_type random $LOCAL_ARGS \
     "

--- a/projects/habitat_ovmm/scripts/test_local.sh
+++ b/projects/habitat_ovmm/scripts/test_local.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 DOCKER_NAME="ovmm_baseline_submission"
+SPLIT="minival"
 
 while [[ $# -gt 0 ]]
 do
@@ -11,6 +12,11 @@ case $key in
       shift
       DOCKER_NAME="${1}"
 	  shift
+      ;;
+      --split)
+      shift
+      SPLIT="${1}"
+      shift
       ;;
     *)
       echo unkown arg ${1}
@@ -24,5 +30,5 @@ docker run \
       --runtime=nvidia \
       --gpus all \
       -e "AGENT_EVALUATION_TYPE=local" \
-      -e "LOCAL_ARGS='habitat.dataset.split=minival'" \
+      -e "LOCAL_ARGS='habitat.dataset.split=${SPLIT}'" \
       ${DOCKER_NAME}

--- a/projects/habitat_ovmm/scripts/test_local.sh
+++ b/projects/habitat_ovmm/scripts/test_local.sh
@@ -24,4 +24,5 @@ docker run \
       --runtime=nvidia \
       --gpus all \
       -e "AGENT_EVALUATION_TYPE=local" \
+      -e "LOCAL_ARGS='habitat.dataset.split=minival'" \
       ${DOCKER_NAME}


### PR DESCRIPTION
## Motivation and Context

Issue #364 

- Previously local docker evaluation was using val episodes, taking very long to return
- Pass a command line argument at the time of local evaluation that runs evaluations on minival split

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->

## Changelog

- Update episodes (release minival episodes) - weren't released previously
- Set a new environment variable inside docker for passing command line arguments for eval
- Set minival as the default split when running local evaluations

<!--- Itemized list of changes -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Tested the docker locally. 


## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [x] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] I ran `tests/hw_manual_test.py` on hardware and observed that robot behavior looks normal.