### PR TITLE
fix: protect against NoneError in heuristic place policy

### DIFF
--- a/src/home_robot/home_robot/manipulation/heuristic_place_policy.py
+++ b/src/home_robot/home_robot/manipulation/heuristic_place_policy.py
@@ -268,7 +268,7 @@ class HeuristicPlacePolicy(nn.Module):
                 thickness=2,
             )
 
-            if vis_inputs is not None:
+            if vis_inputs is not None and vis_inputs["semantic_frame"] is not None:
                 vis_inputs["semantic_frame"][..., :3] = rgb_vis_tmp
 
             # Add placement margin to the best voxel that we chose


### PR DESCRIPTION
## Motivation and Context

Fixes a NoneError when using the heuristic place skill in the ovmm challenge demo. I ran into an issue where `vis_inputs["semantic_frame"]` is None: this change protects access to it when None.

This is a very small fix PR, are you interested in unsolicited small fixes like these? I know it can be a pain to review and understand if you'd rather fix them in a larger sweep internally. If yes I don't mind closing it.

## Changelog

Add a guard against NoneErrors in heuristic place skill.

## How Has This Been Tested

- Before change, the heuristic place skill threw a NoneError.
- After change, the heuristic place skill succeeds and a run can complete.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] I ran `tests/hw_manual_test.py` on hardware and observed that robot behavior looks normal.