### PR TITLE
feat: specify detic object recognition confidence threshold in agent config

### DIFF
--- a/projects/habitat_ovmm/configs/agent/heuristic_agent.yaml
+++ b/projects/habitat_ovmm/configs/agent/heuristic_agent.yaml
@@ -5,6 +5,10 @@ radius: 0.05            # robot radius (in meters)
 fall_wait_steps: 200    # number of steps to wait after the object has been dropped
 store_all_categories: False  # whether to store all semantic categories in the map or just task-relevant ones
 detection_module: detic # the detector to use for perception in case ground_truth_semantics are turned off
+
+VISION:
+  confidence_threshold: 0.45 # detic object detection confidence threshold
+
 SEMANTIC_MAP:
   semantic_categories: rearrange # map semantic channel categories ("coco_indoor", "longtail_indoor", "mukul_indoor", "rearrange")
   num_sem_categories: 5    # Following 5 categories: ["misc", "object_category", "start_receptacle", "goal_receptacle", "others"]

--- a/projects/habitat_ovmm/configs/agent/rl_agent.yaml
+++ b/projects/habitat_ovmm/configs/agent/rl_agent.yaml
@@ -6,6 +6,9 @@ fall_wait_steps: 200    # number of steps to wait after the object has been drop
 store_all_categories: False  # whether to store all semantic categories in the map or just task-relevant ones
 detection_module: detic # the detector to use for perception in case ground_truth_semantics are turned off
 
+VISION:
+  confidence_threshold: 0.45 # detic object detection confidence threshold
+
 SEMANTIC_MAP:
   semantic_categories: rearrange # map semantic channel categories ("coco_indoor", "longtail_indoor", "mukul_indoor", "rearrange")
   num_sem_categories: 5    # Following 5 categories: ["misc", "object_category", "start_receptacle", "goal_receptacle", "others"]

--- a/src/home_robot/home_robot/agent/ovmm_agent/ovmm_agent.py
+++ b/src/home_robot/home_robot/agent/ovmm_agent/ovmm_agent.py
@@ -73,7 +73,12 @@ class OpenVocabManipAgent(ObjectNavAgent):
         self.skip_skills = config.AGENT.skip_skills
         self.max_pick_attempts = 100
         if config.GROUND_TRUTH_SEMANTICS == 0:
-            self.semantic_sensor = OvmmPerception(config, device_id, self.verbose)
+            self.semantic_sensor = OvmmPerception(
+                config,
+                device_id,
+                self.verbose,
+                confidence_threshold=config.AGENT.VISION.confidence_threshold,
+            )
             self.obj_name_to_id, self.rec_name_to_id = read_category_map_file(
                 config.ENVIRONMENT.category_map_file
             )

--- a/src/home_robot/home_robot/perception/wrapper.py
+++ b/src/home_robot/home_robot/perception/wrapper.py
@@ -26,6 +26,7 @@ class OvmmPerception:
         config,
         gpu_device_id: int = 0,
         verbose: bool = False,
+        confidence_threshold: float = 0.5,
         module: str = "grounded_sam",
         module_kwargs: Dict[str, Any] = {},
     ):
@@ -42,12 +43,12 @@ class OvmmPerception:
                 DeticPerception,
             )
 
-            # TODO Specify confidence threshold as a parameter
             self._segmentation = DeticPerception(
                 vocabulary="custom",
                 custom_vocabulary=".",
                 sem_gpu_id=gpu_device_id,
                 verbose=verbose,
+                confidence_threshold=confidence_threshold,
                 **module_kwargs,
             )
         elif self._detection_module == "grounded_sam":


### PR DESCRIPTION
## Motivation and Context

Resolves a TODO in the code.

Lower confidence thresholds can be used to move some object recognition decisions to the heuristic agent, for example to allow lower confidence levels for rarer classes of objects.  

## Changelog

- Add a new section VISION to agent config
  - can inline if you want to but feels useful to separate vision related config from others.
- add confidence_threshold param to above section, default 0.05 (I believe this is what was used previously by default)
- pass said param in code to `DeticPerception` which accepts it.

## How Has This Been Tested

Runs locally and works.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] I ran `tests/hw_manual_test.py` on hardware and observed that robot behavior looks normal.