### PR TITLE
Camera pose sequence length and hssd_demo fixes

### DIFF
--- a/projects/habitat_ovmm/configs/env/hssd_demo.yaml
+++ b/projects/habitat_ovmm/configs/env/hssd_demo.yaml
@@ -31,6 +31,7 @@ EVAL_VECTORIZED:
   record_planner_videos: 0  # 1: record planner videos (if record videos), 0: don't
   metrics_save_freq: 5      # save metrics after every n episodes
 
+# The below goal names are used only in real world, in simulation these come from episodes
 start_recep: "chair"
 pick_object: "bowl"
 goal_recep: "table"

--- a/src/home_robot/home_robot/agent/exploration_agent/exploration_agent.py
+++ b/src/home_robot/home_robot/agent/exploration_agent/exploration_agent.py
@@ -138,7 +138,7 @@ class ExplorationAgent(Agent):
             pose_delta.unsqueeze(1),
             dones.unsqueeze(1),
             update_global.unsqueeze(1),
-            camera_pose,
+            camera_pose.unsqueeze(1),
             self.geometric_map.local_map,
             self.geometric_map.global_map,
             self.geometric_map.local_pose,

--- a/src/home_robot/home_robot/agent/exploration_agent/exploration_agent_module.py
+++ b/src/home_robot/home_robot/agent/exploration_agent/exploration_agent_module.py
@@ -71,7 +71,7 @@ class ExplorationAgentModule(nn.Module):
              indicate episode restarts
             seq_update_global: sequence of (batch_size, sequence_length) binary
              flags that indicate whether to update the global map and pose
-            seq_camera_poses: sequence of (batch_size, 4, 4) camera poses
+            seq_camera_poses: sequence of (batch_size, sequence_length, 4, 4) camera poses
             init_local_map: initial local map before any updates of shape
              (batch_size, 4, M, M)
             init_global_map: initial global map before any updates of shape

--- a/src/home_robot/home_robot/agent/imagenav_agent/imagenav_agent.py
+++ b/src/home_robot/home_robot/agent/imagenav_agent/imagenav_agent.py
@@ -140,7 +140,7 @@ class IINAgentModule(nn.Module):
              indicate episode restarts
             seq_update_global: sequence of (batch_size, sequence_length) binary
              flags that indicate whether to update the global map and pose
-            seq_camera_poses: sequence of (batch_size, 4, 4) camera poses
+            seq_camera_poses: sequence of (batch_size, sequence_length, 4, 4) camera poses
             init_local_map: initial local map before any updates of shape
              (batch_size, 4 + num_sem_categories, M, M)
             init_global_map: initial global map before any updates of shape
@@ -394,7 +394,7 @@ class ImageNavAgent(Agent):
             pose_delta.unsqueeze(1),
             dones.unsqueeze(1),
             update_global.unsqueeze(1),
-            camera_pose,
+            camera_pose.unsqueeze(1),
             self.found_goal,
             self.goal_map,
             self.semantic_map.local_map,

--- a/src/home_robot/home_robot/agent/objectnav_agent/objectnav_agent.py
+++ b/src/home_robot/home_robot/agent/objectnav_agent/objectnav_agent.py
@@ -225,7 +225,7 @@ class ObjectNavAgent(Agent):
             pose_delta.unsqueeze(1),
             dones.unsqueeze(1),
             update_global.unsqueeze(1),
-            camera_pose,
+            camera_pose.unsqueeze(1),
             self.semantic_map.local_map,
             self.semantic_map.global_map,
             self.semantic_map.local_pose,

--- a/src/home_robot/home_robot/agent/objectnav_agent/objectnav_agent_module.py
+++ b/src/home_robot/home_robot/agent/objectnav_agent/objectnav_agent_module.py
@@ -109,7 +109,7 @@ class ObjectNavAgentModule(nn.Module):
              indicate episode restarts
             seq_update_global: sequence of (batch_size, sequence_length) binary
              flags that indicate whether to update the global map and pose
-            seq_camera_poses: sequence of (batch_size, 4, 4) camera poses
+            seq_camera_poses: sequence of (batch_size, sequence_length, 4, 4) camera poses
             init_local_map: initial local map before any updates of shape
              (batch_size, 4 + num_sem_categories, M, M)
             init_global_map: initial global map before any updates of shape

--- a/src/home_robot/home_robot/agent/objectnav_agent/reset_nav_agent.py
+++ b/src/home_robot/home_robot/agent/objectnav_agent/reset_nav_agent.py
@@ -225,7 +225,7 @@ class ResetNavAgent(Agent):
             pose_delta.unsqueeze(1),
             dones.unsqueeze(1),
             update_global.unsqueeze(1),
-            camera_pose,
+            camera_pose.unsqueeze(1),
             self.semantic_map.local_map,
             self.semantic_map.global_map,
             self.semantic_map.local_pose,

--- a/src/home_robot/home_robot/agent/ovmm_agent/ovmm_agent.py
+++ b/src/home_robot/home_robot/agent/ovmm_agent/ovmm_agent.py
@@ -136,7 +136,7 @@ class OpenVocabManipAgent(ObjectNavAgent):
         """Get inputs for visual skill."""
         use_detic_viz = self.config.ENVIRONMENT.use_detic_viz
 
-        if self.config.GROUND_TRUTH_SEMANTICS == 1 or use_detic_viz:
+        if self.config.GROUND_TRUTH_SEMANTICS == 1:
             semantic_category_mapping = None  # Visualizer handles mapping
         elif self.semantic_sensor.current_vocabulary_id == SemanticVocab.SIMPLE:
             semantic_category_mapping = RearrangeBasicCategories()
@@ -144,7 +144,13 @@ class OpenVocabManipAgent(ObjectNavAgent):
             semantic_category_mapping = self.semantic_sensor.current_vocabulary
 
         if use_detic_viz:
-            semantic_frame = obs.task_observations["semantic_frame"]
+            semantic_frame = np.concatenate(
+                [
+                    obs.task_observations["semantic_frame"],
+                    obs.semantic[:, :, np.newaxis],
+                ],
+                axis=2,
+            ).astype(np.uint8)
         else:
             semantic_frame = np.concatenate(
                 [obs.rgb, obs.semantic[:, :, np.newaxis]], axis=2

--- a/src/home_robot/home_robot/agent/ovmm_agent/ovmm_agent.py
+++ b/src/home_robot/home_robot/agent/ovmm_agent/ovmm_agent.py
@@ -155,9 +155,7 @@ class OpenVocabManipAgent(ObjectNavAgent):
             semantic_frame = np.concatenate(
                 [obs.rgb, obs.semantic[:, :, np.newaxis]], axis=2
             ).astype(np.uint8)
-        goal_name = getattr(
-            self.config, "pick_object", obs.task_observations["goal_name"]
-        )
+        goal_name = obs.task_observations["goal_name"]
         info = {
             "semantic_frame": semantic_frame,
             "semantic_category_mapping": semantic_category_mapping,
@@ -295,15 +293,9 @@ class OpenVocabManipAgent(ObjectNavAgent):
         :update_full_vocabulary: if False, only updates simple vocabulary
         True by default
         """
-        object_name = getattr(
-            self.config, "pick_object", obs.task_observations["object_name"]
-        )
-        start_recep_name = getattr(
-            self.config, "start_recep", obs.task_observations["start_recep_name"]
-        )
-        goal_recep_name = getattr(
-            self.config, "goal_recep", obs.task_observations["place_recep_name"]
-        )
+        object_name = obs.task_observations["object_name"]
+        start_recep_name = obs.task_observations["start_recep_name"]
+        goal_recep_name = obs.task_observations["place_recep_name"]
         obj_id_to_name = {
             0: object_name,
         }

--- a/src/home_robot/home_robot/mapping/geometric/geometric_map_module.py
+++ b/src/home_robot/home_robot/mapping/geometric/geometric_map_module.py
@@ -144,7 +144,7 @@ class GeometricMapModule(nn.Module):
              that indicate episode restarts
             seq_update_global: sequence of (batch_size, sequence_length) binary
              flags that indicate whether to update the global map and pose
-            seq_camera_poses: sequence of (batch_size, 4, 4) extrinsic camera
+            seq_camera_poses: sequence of (batch_size, sequence_length, 4, 4) extrinsic camera
              matrices
             init_local_map: initial local map before any updates of shape
              (batch_size, MC.NON_SEM_CHANNELS, M, M)
@@ -216,7 +216,7 @@ class GeometricMapModule(nn.Module):
                 seq_pose_delta[:, t],
                 local_map,
                 local_pose,
-                seq_camera_poses,
+                seq_camera_poses[:, t],
             )
 
             for e in range(batch_size):

--- a/src/home_robot/home_robot/mapping/semantic/categorical_2d_semantic_map_module.py
+++ b/src/home_robot/home_robot/mapping/semantic/categorical_2d_semantic_map_module.py
@@ -201,7 +201,7 @@ class Categorical2DSemanticMapModule(nn.Module):
              that indicate episode restarts
             seq_update_global: sequence of (batch_size, sequence_length) binary
              flags that indicate whether to update the global map and pose
-            seq_camera_poses: sequence of (batch_size, 4, 4) extrinsic camera
+            seq_camera_poses: sequence of (batch_size, sequence_length, 4, 4) extrinsic camera
              matrices
             init_local_map: initial local map before any updates of shape
              (batch_size, MC.NON_SEM_CHANNELS + num_sem_categories, M, M)
@@ -277,7 +277,7 @@ class Categorical2DSemanticMapModule(nn.Module):
                 seq_pose_delta[:, t],
                 local_map,
                 local_pose,
-                seq_camera_poses,
+                seq_camera_poses[:, t],
                 origins,
                 lmb,
                 seq_obstacle_locations[:, t]

--- a/src/home_robot_hw/home_robot_hw/env/visualizer.py
+++ b/src/home_robot_hw/home_robot_hw/env/visualizer.py
@@ -265,7 +265,7 @@ class Visualizer:
             print(self.image_vis.shape, SEMANTIC_MAP_ORIG_X, SEMANTIC_MAP_ORIG_Y, width)
 
         # First-person semantic frame
-        semantic_frame = cv2.cvtColor(semantic_frame, cv2.COLOR_BGR2RGB)
+        semantic_frame = cv2.cvtColor(semantic_frame[:, :, :3], cv2.COLOR_BGR2RGB)
         self.image_vis[50:530, 15:375] = cv2.resize(semantic_frame, (360, 480))
 
         if self.show_images:


### PR DESCRIPTION
## Motivation and Context
Issues #452 and #464 

1. Fix `detic_viz=True` errors in sim
2. Issue #464 Use goal names from observations in ovmm_agent. In the real world env, these are set [here](https://github.com/facebookresearch/home-robot/blob/e4149d5d32c9735043a7efc49c377337a6bdb678/src/home_robot_hw/home_robot_hw/env/stretch_pick_and_place_env.py#L430) and also get used [here](https://github.com/facebookresearch/home-robot/blob/e4149d5d32c9735043a7efc49c377337a6bdb678/src/home_robot/home_robot/perception/wrapper.py#L127). So this change should not break the real world stack.
3. Issue #452 Update camera_pose shape at all places where a sequence of observations could be passed to map building module.


<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->

## Changelog

<!--- Itemized list of changes -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
Tested in simulation env. We may want to test the baseline in real world to confirm nothing breaks.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] I ran `tests/hw_manual_test.py` on hardware and observed that robot behavior looks normal.