### PR TITLE
Pin sophuspy version to 0.0.8 

### DIFF
--- a/src/home_robot/requirements.txt
+++ b/src/home_robot/requirements.txt
@@ -1,6 +1,6 @@
 numpy <1.24 # certain deprecated operations were used in other deps
 scipy
-sophuspy
+sophuspy <1.0.0
 opencv-python
 pybullet
 trimesh

--- a/src/home_robot/setup.py
+++ b/src/home_robot/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     "open3d",
     "numpy-quaternion",
     "pybind11-global",
-    "sophuspy",
+    "sophuspy==0.0.8",
     "trimesh",
     "pin>=2.6.17",
     "torch_cluster",


### PR DESCRIPTION
## Motivation and Context

It seems like there has been recent changes in sophuspy library. This PR pins version to 0.0.8 to check if tests pass.
https://github.com/facebookresearch/home-robot/issues/477

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->

## Changelog

<!--- Itemized list of changes -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:

- [ ] I have made changes to existing documentation where needed.
- [ ] I have added tests that show that the PR is functional.
- [ ] I ran `tests/hw_manual_test.py` on hardware and observed that robot behavior looks normal.