### PR TITLE
Convert the CircleCI workflow to a GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,70 @@
+name: facebookresearch/home-robot/main
+on:
+  push:
+    branches:
+    - main
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.0
+      - name: Running precommit checks
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+          run: |
+            pip install pre-commit
+            pre-commit install-hooks
+            pre-commit run --all-files
+  home_robot:
+    runs-on: ubuntu-latest
+    env:
+      FPS_THRESHOLD: 900
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - name: Install system deps
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends build-essential vim ca-certificates python3-dev autotools-dev libicu-dev libbz2-dev libboost-all-dev pandoc
+    - name: Setup Conda environment
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        activate-environment: env_home_robot
+    - name: Run tests
+      run: |
+        conda install -n env_home_robot -y -c conda-forge pinocchio>=2.6.17
+        pip install torch 'pypandoc<1.8'
+        pip install -e src/home_robot
+        cd tests/home_robot
+        pytest .
+  home_robot_sim:
+    runs-on: ubuntu-latest
+    env:
+      FPS_THRESHOLD: 900
+    steps:
+    - uses: actions/checkout@v4.1.0
+    - name: Install system deps
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends build-essential vim ca-certificates libbullet-dev libjpeg-dev libglm-dev libegl1-mesa-dev xorg-dev freeglut3-dev libhdf5-dev
+    - name: Sync submodules
+      run: |
+        git submodule sync
+        git submodule update --init src/third_party/habitat-lab
+    - name: Setup Conda environment
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        activate-environment: env_home_robot
+    - name: Install home-robot-sim dependencies & download data
+      run: |
+        conda install -n env_home_robot -y -c conda-forge pinocchio>=2.6.17
+        pip install -e src/third_party/habitat-lab
+        python -m habitat_sim.utils.datasets_download --uids mp3d_example_scene --data-path data/
+        mkdir -p tests/home_robot_sim/data/scene_datasets/mp3d_example/mp3d
+        mv data/scene_datasets/mp3d_example/17DRP5sb8fy tests/home_robot_sim/data/scene_datasets/mp3d_example/mp3d
+    - name: Install libraries and run tests
+      run: |
+        sudo pip install -e src/home_robot
+        sudo pip install -e src/home_robot_sim
+        cd tests/home_robot_sim
+        pytest .


### PR DESCRIPTION
## Summary

This pull request converts the CircleCI workflows to GitHub actions workflows. [Github Actions Importer](https://github.com/github/gh-actions-importer) was used to convert the workflows initially, then I edited them manually to correct errors in translation.

**Issues**

1. _facebook/home-robot/build -> home_robot_

```
RuntimeError: Format missing, but need one (identified source as text as no file with that name was found).
```

<details>
<summary style="list-style-type: none;">Full Error</summary>
<pre>
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [10 lines of output]
      /tmp/pip-install-qrj2sd_2/trimesh_7e72dfdab9294065833084684cd6df2f/setup.py:10: DeprecationWarning: Due to possible ambiguity, 'convert()' is deprecated and will be removed in pypandoc 1.8. Use 'convert_file()'  or 'convert_text()'.
        long_description = pypandoc.convert('README.md', 'rst')
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-qrj2sd_2/trimesh_7e72dfdab9294065833084684cd6df2f/setup.py", line 10, in <module>
          long_description = pypandoc.convert('README.md', 'rst')
        File "/home/runner/.local/lib/python3.10/site-packages/pypandoc/__init__.py", line 70, in convert
          raise RuntimeError("Format missing, but need one (identified source as text as no "
      RuntimeError: Format missing, but need one (identified source as text as no file with that name was found).
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
</pre>
</details>

2. _facebook/home-robot/build -> home_robot_sim_

```
[Errno 13] Permission denied: '/usr/local/lib/python3.10/dist-packages/test-easy-install-3396.write-test'
```

<details>
<summary style="list-style-type: none;">Full Error</summary>
<pre>
× python setup.py develop did not run successfully.
│ exit code: 1
╰─> [32 lines of output]
    running develop
    /usr/lib/python3/dist-packages/setuptools/command/easy_install.py:158: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
      warnings.warn(
    WARNING: The user site-packages directory is disabled.
    /usr/lib/python3/dist-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
      warnings.warn(
    error: can't create or remove files in install directory
    
    The following error occurred while trying to add or remove files in the
    installation directory:
    
        [Errno 13] Permission denied: '/usr/local/lib/python3.10/dist-packages/test-easy-install-3396.write-test'
    
    The installation directory you specified (via --install-dir, --prefix, or
    the distutils default setting) was:
    
        /usr/local/lib/python3.10/dist-packages/
    
    Perhaps your account does not have write access to this directory?  If the
    installation directory is a system-owned directory, you may need to sign in
    as the administrator or "root" account.  If you do not have administrative
    access to this machine, you may wish to choose a different installation
    directory, preferably one that is listed in your PYTHONPATH environment
    variable.
    
    For information on other options, you may wish to consult the
    documentation at:
    
      https://setuptools.pypa.io/en/latest/deprecated/easy_install.html
    
    Please make the appropriate changes for your system and try again.
    
    [end of output]

note: This error originates from a subprocess, and is likely not a problem with pip.
</pre>
</details>

## How did you test this change?

I tested these changes in a [forked repo](https://github.com/robandpdx-org/home-robot/actions/runs/8836135902).

https://fburl.com/workplace/f6mz6tmw